### PR TITLE
Set smoothq_alpha as buffer

### DIFF
--- a/fms_mo/modules/linear.py
+++ b/fms_mo/modules/linear.py
@@ -343,10 +343,7 @@ class QLinear(nn.Linear):
             else:
                 alpha = self.smoothq_alpha
             smoothq_scale = (
-                (
-                    self.smoothq_act_scale.pow(alpha)
-                    / weight_scale.pow(1.0 - alpha)
-                )
+                (self.smoothq_act_scale.pow(alpha) / weight_scale.pow(1.0 - alpha))
                 .clamp(min=1e-5)
                 .to(x.dtype)
             )

--- a/fms_mo/modules/linear.py
+++ b/fms_mo/modules/linear.py
@@ -223,7 +223,10 @@ class QLinear(nn.Linear):
         self.smoothq = qcfg.get("smoothq", False)
         if self.smoothq:
             self.register_buffer("smoothq_act_scale", torch.zeros(w_size[1]))
-            self.smoothq_alpha = qcfg.get("smoothq_alpha", 0.5)
+            self.register_buffer(
+                "smoothq_alpha",
+                torch.tensor([qcfg.get("smoothq_alpha", 0.5)], dtype=torch.float32),
+            )
 
     def forward(self, x):
         """
@@ -335,10 +338,14 @@ class QLinear(nn.Linear):
             smoothq_scale = torch.tensor([1.0]).to(x.dtype).to(x.device)
         else:
             weight_scale = self.weight.abs().max(dim=0, keepdim=True)[0].clamp(min=1e-5)
+            if isinstance(self.smoothq_alpha, torch.Tensor):
+                alpha = self.smoothq_alpha.item()
+            else:
+                alpha = self.smoothq_alpha
             smoothq_scale = (
                 (
-                    self.smoothq_act_scale.pow(self.smoothq_alpha)
-                    / weight_scale.pow(1.0 - self.smoothq_alpha)
+                    self.smoothq_act_scale.pow(alpha)
+                    / weight_scale.pow(1.0 - alpha)
                 )
                 .clamp(min=1e-5)
                 .to(x.dtype)


### PR DESCRIPTION
### Description of the change

This PR defines `smoothquant_alpha` as a buffer, so that it gets stored in the model state dictionary and checkpoint. 
This allows to automatically retrieve this value at the time the checkpoint is re-loaded (so that the user does not need to re-define it manually, which is prone to errors) and to use it in the re-computation of the smoothquant_scale that was applied during training.

### Related issue number

n/a

### How to verify the PR

small code change

### Was the PR tested

Yes
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [X] I have ensured all unit tests pass