### PR TITLE
Fix device for smoothquant activation scales

### DIFF
--- a/fms_mo/quant/ptq.py
+++ b/fms_mo/quant/ptq.py
@@ -2420,7 +2420,7 @@ def get_act_scales(
 
     for data_mb, _ in zip(pbar, range(n_samples)):
         qcfg["sample_id"] += 1
-        data_mb = move_to(data_mb, dev)
+        data_mb = move_to(data_mb, device)
         if (
             qcfg["nbits_bmm1"] < 32
             or qcfg["nbits_bmm2"] < 32

--- a/fms_mo/quant/ptq.py
+++ b/fms_mo/quant/ptq.py
@@ -2404,7 +2404,6 @@ def get_act_scales(
         )
         model.to(device)
 
-    dev = next(model.parameters()).device
     act_scales = {}
     qcfg["sample_id"] = 0
     hooks = []
@@ -2421,7 +2420,7 @@ def get_act_scales(
 
     for data_mb, _ in zip(pbar, range(n_samples)):
         qcfg["sample_id"] += 1
-        data_mb = move_to(data_mb, dev)
+        data_mb = move_to(data_mb, device)
         if (
             qcfg["nbits_bmm1"] < 32
             or qcfg["nbits_bmm2"] < 32

--- a/fms_mo/quant/ptq.py
+++ b/fms_mo/quant/ptq.py
@@ -23,7 +23,7 @@ search_fold_and_remove_bn are modified from QDROP repo https://github.com/wimh96
 
 # Standard
 from functools import partial
-from typing import Optional
+from typing import Optional, Union
 import logging
 import math
 import random
@@ -2388,7 +2388,7 @@ def get_act_scales(
     model,
     dloader,
     qcfg: dict,
-    device: Optional[str | torch.device] = None,
+    device: Optional[Union[str, torch.device]] = None,
 ):
     """Compute smoothquant activation scales of quantized linear layers.
     Model and examples are moved to selected device, if provided.
@@ -2420,7 +2420,7 @@ def get_act_scales(
 
     for data_mb, _ in zip(pbar, range(n_samples)):
         qcfg["sample_id"] += 1
-        data_mb = move_to(data_mb, device)
+        data_mb = move_to(data_mb, dev)
         if (
             qcfg["nbits_bmm1"] < 32
             or qcfg["nbits_bmm2"] < 32

--- a/fms_mo/quant/ptq.py
+++ b/fms_mo/quant/ptq.py
@@ -15,7 +15,7 @@
 """
 Post-Training Quantization (PTQ) functions
 
-Class StraightThrough, function _fold_bn, fold_bn_into_conv, reset_bn, and 
+Class StraightThrough, function _fold_bn, fold_bn_into_conv, reset_bn, and
 search_fold_and_remove_bn are modified from QDROP repo https://github.com/wimh966/QDrop
 
 
@@ -23,6 +23,7 @@ search_fold_and_remove_bn are modified from QDROP repo https://github.com/wimh96
 
 # Standard
 from functools import partial
+from typing import Optional
 import logging
 import math
 import random
@@ -2383,14 +2384,26 @@ def input_stats_hook(m, x, _y, name, act_scales):
 
 
 @torch.no_grad()
-def get_act_scales(model, dloader, qcfg):
-    """
-    To get max() of activations for linear layers on one device.
-    Model size will be limited by memory (GPU) or speed (cpu)
+def get_act_scales(
+    model,
+    dloader,
+    qcfg: dict,
+    device: Optional[str | torch.device] = None,
+):
+    """Compute smoothquant activation scales of quantized linear layers.
+    Model and examples are moved to selected device, if provided.
     """
 
     model.eval()
-    model.cuda()
+
+    if device is None:
+        device = next(model.parameters()).device
+    else:
+        logger.info(
+            f"Moving model to {device} to compute smoothquant activation scales"
+        )
+        model.to(device)
+
     dev = next(model.parameters()).device
     act_scales = {}
     qcfg["sample_id"] = 0
@@ -2408,7 +2421,6 @@ def get_act_scales(model, dloader, qcfg):
 
     for data_mb, _ in zip(pbar, range(n_samples)):
         qcfg["sample_id"] += 1
-        # logger.info("Now for sample: ", qcfg["sample_id"] )
         data_mb = move_to(data_mb, dev)
         if (
             qcfg["nbits_bmm1"] < 32


### PR DESCRIPTION
This PR fixes the behavior of `get_act_scales` function, which calculates the activation scales for smoothquant, in the case they have *not* been pre-computed and provided by the user. Before this change, *this function always moved the full model to GPU* (using `model.cuda()`) before computing the activation scales. This is not compatible with operations in CPU-only environments, nor with handling of large models. This PR fixes this issue, by adding an optional `device` argument to the function. If `device` is not passed, computations will not alter the current model device. Otherwise, the selected device will be used (both model and batches will be moved to that device).

### Related issue number

n/a

### How to verify the PR

n/a

### Was the PR tested

- [ ] I have added >=1 unit test(s) for every new method I have added.
- [X] I have ensured all unit tests pass