### PR TITLE
tox: Add base Python version to tox environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py, lint, fmt
+envlist = fmt, lint, unit
 minversion = 4.4
 
 [testenv]
@@ -11,18 +11,26 @@ wheel_build_env = pkg
 deps =
     pytest
 commands =
-    pytest {posargs:tests}
+    unit: {basepython} -m pytest {posargs:tests}
+
+[testenv:py3]
+basepython = python3.11
+
+[testenv:unit]
+basepython = {[testenv:py3]basepython}
 
 [testenv:lint]
+basepython = {[testenv:py3]basepython}
 description = lint with pylint
 deps =
     pytest
     pylint>=2.16.2,<4.0
     pylint-pydantic
 commands =
-    {envpython} -m pylint --load-plugins pylint_pydantic fms_mo/ tests/
+    {basepython} -m pylint --load-plugins pylint_pydantic fms_mo/ tests/
 
 [testenv:fmt]
+basepython = {[testenv:py3]basepython}
 description = format with pre-commit
 deps =
     pre-commit

--- a/tox.ini
+++ b/tox.ini
@@ -51,3 +51,9 @@ commands =
     coverage report -m
     coverage xml
     genbadge coverage -s -i coverage.xml
+
+[gh]
+python =
+    3.11 = 3.11
+    3.10 = 3.10
+    3.9 = 3.9


### PR DESCRIPTION
### Description of the change

Adding the base Python version means that the `tox` runtime will now use this version instead of the `tox` environment version. It means we can specify the version as is supported by the project.

### Related issue number
Closes #23 

### How to verify the PR

Run `tox` from the project root.

### Was the PR tested

- [x] I have ensured all unit tests pass