### PR TITLE
Fix symmetric behavior (issue #22)

### DIFF
--- a/fms_mo/calib.py
+++ b/fms_mo/calib.py
@@ -90,10 +90,9 @@ class ObserverPercentile(nn.Module):
                     x.reshape(1, -1).kthvalue(int(self.per[1] * nelem)).values.data[0]
                 )
                 if symmetric:
-                    upper_per_cur = (
-                        upper_per_cur_candidate
-                        if upper_per_cur_candidate > lower_per_cur_candidate.abs()
-                        else lower_per_cur_candidate.abs()
+                    upper_per_cur = max(
+                        upper_per_cur_candidate,
+                        lower_per_cur_candidate.abs(),
                     )
                     lower_per_cur = -upper_per_cur
                 else:

--- a/fms_mo/modules/linear.py
+++ b/fms_mo/modules/linear.py
@@ -162,12 +162,17 @@ class QLinear(nn.Linear):
                 use_subnormal=self.fp8_use_subnormal,
             )
             if self.calib_counter > 0:
+                qa_mode_calib = (
+                    self.qa_mode_calib + "sym"
+                    if self.qa_mode.endswith("sym")
+                    else self.qa_mode_calib
+                )
                 self.quantize_calib_feature = Qdynamic(
                     self.num_bits_feature,
                     qcfg,
                     non_neg=self.non_neg,
                     align_zero=self.align_zero,
-                    qmode=self.qa_mode_calib,
+                    qmode=qa_mode_calib,
                     quantizer2sync=self.quantize_feature,
                 )
 

--- a/fms_mo/quant/quantizers.py
+++ b/fms_mo/quant/quantizers.py
@@ -3512,7 +3512,7 @@ class Qdynamic(nn.Module):
         """
         super().__init__()
         self.num_bits = num_bits
-        self.symmetric = symmetric or qmode.endswith("_sym")
+        self.symmetric = symmetric or qmode.endswith("sym")
         self.nlevels = (
             2**self.num_bits - 2 if self.symmetric else 2**self.num_bits - 1
         )
@@ -3553,7 +3553,7 @@ class Qdynamic(nn.Module):
         with torch.no_grad():
             if self.qmode.startswith("percentile"):
                 nelem = input_tensor.nelement()
-                cv_new = (
+                cv_new_candidate = (
                     input_tensor.reshape(1, -1)
                     .float()
                     .kthvalue(
@@ -3561,16 +3561,28 @@ class Qdynamic(nn.Module):
                     )  # built-in 'round' returns int
                     .values.data[0]
                 ).to(input_tensor.dtype)
+
                 # conventionaly percentile is input_tensor as 99.9 (% is implied),
                 # so we need *0.01 here
                 lower_k = round(self.per[0] * 0.01 * nelem)
-                cvn_new = (
+                cvn_new_candidate = (
                     input_tensor.reshape(1, -1).float().kthvalue(lower_k).values.data[0]
                     if lower_k > 0
                     else input_tensor.min()
                 ).to(
                     input_tensor.dtype
                 )  # for very small tensor, lower_k could be 0, kthvalue(0) will cause error
+
+                if self.symmetric:
+                    cv_new = (
+                        cv_new_candidate
+                        if cv_new_candidate > cvn_new_candidate.abs()
+                        else cvn_new_candidate.abs()
+                    )
+                    cvn_new = -cv_new
+                else:
+                    cv_new = cv_new_candidate
+                    cvn_new = cvn_new_candidate
             elif (
                 self.qmode == "sawb" and self.num_bits == 4
             ):  # only works for PACT+sym for weights
@@ -3579,7 +3591,7 @@ class Qdynamic(nn.Module):
 
             else:  # i.e., minmax
                 cv_new = input_tensor.max()
-                cvn_new = input_tensor.min()
+                cvn_new = -cv_new if self.symmetric else input_tensor.min()
 
             if self.Niter == 0 and self.training:
                 # to avoid unintended bwd ops added to the graph, cause memory leak sometimes

--- a/fms_mo/quant/quantizers.py
+++ b/fms_mo/quant/quantizers.py
@@ -3574,11 +3574,7 @@ class Qdynamic(nn.Module):
                 )  # for very small tensor, lower_k could be 0, kthvalue(0) will cause error
 
                 if self.symmetric:
-                    cv_new = (
-                        cv_new_candidate
-                        if cv_new_candidate > cvn_new_candidate.abs()
-                        else cvn_new_candidate.abs()
-                    )
+                    cv_new = max(cv_new_candidate, cvn_new_candidate.abs())
                     cvn_new = -cv_new
                 else:
                     cv_new = cv_new_candidate


### PR DESCRIPTION
### Description of the change

Enforcing symmetry of activation clips during calibration, if a symmetric quantizer was chosen. 
Modified observers (`qmodel_calibration` route) and Qdynamic (`qmodel_calibration_new` route).
This PR does not cover all supported symmetric quantizers, only those carrying the `minmax` attribute (for `qmodel_calibration`) or those selected with `qa_mode` ending in `sym` (for `qmodel_calibration_new`).

### Related issue number

#22 

### How to verify the PR

n/a

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [X] I have ensured all unit tests pass