### PR TITLE
fix: Error in quantization notebook tutorial when retrieving image

### DIFF
--- a/tutorials/quantization_tutorial.ipynb
+++ b/tutorials/quantization_tutorial.ipynb
@@ -105,7 +105,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install fms-model-optimizer"
+    "! pip install fms-model-optimizer\n",
+    "! pip install wget"
    ]
   },
   {


### PR DESCRIPTION
### Description of the change

in quantization tutorial, `wget` package is not installed by the notebook and therefore errors out when used to get the image from the repository.

```python
import os, wget
IMG_FILE_NAME = 'lion.png'
url = 'https://raw.githubusercontent.com/foundation-model-stack/fms-model-optimizer/main/tutorials/images/' + IMG_FILE_NAME

if not os.path.isfile(IMG_FILE_NAME):
  wget.download(url, out=IMG_FILE_NAME)

img = Image.open(IMG_FILE_NAME)
img
```
```shell
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
<ipython-input-21-3f698ed880ba> in <cell line: 1>()
----> 1 import os, wget
      2 IMG_FILE_NAME = 'lion.png'
      3 url = 'https://raw.githubusercontent.com/foundation-model-stack/fms-model-optimizer/main/tutorials/images/' + IMG_FILE_NAME
      4 
      5 if not os.path.isfile(IMG_FILE_NAME):

ModuleNotFoundError: No module named 'wget'
```

### How to verify the PR

Test running notebook using Jupyter locally or Colab hosted remotely.

### Was the PR tested

- [x] I have ensured all unit tests pass