### PR TITLE
Add mypy static checker tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,3 +122,24 @@ from-first=true
 # import_heading_localfolder="Local"
 known-local-folder=["fms_mo","tests"]
 # extend-skip="fms_mo/_version.py"
+
+[tool.mypy]
+mypy_path = [""]
+packages = ["fms_mo", "tests"]
+disable_error_code = []
+# TODO: tighten MyPy checks by enabling these checks over time.
+check_untyped_defs = false
+disallow_incomplete_defs = false
+disallow_untyped_defs = false
+warn_return_any = true
+# honor excludes by not following there through imports
+follow_imports = "silent"
+exclude = []
+
+[[tool.mypy.overrides]]
+# packages without typing annotations, without stubs, or not available.
+module = [
+  "datasets",
+  "huggingface_hub.*",
+]
+ignore_missing_imports = true

--- a/tox.ini
+++ b/tox.ini
@@ -74,6 +74,20 @@ commands =
     {envpython} -m pyspelling --config {toxinidir}/.spellcheck.yml --spellchecker aspell
 allowlist_externals = sh
 
+[testenv:mypy]
+description = Python type checking with mypy
+basepython = {[testenv:py3]basepython}
+deps =
+  mypy>=1.10.0,<1.14
+  types-PyYAML
+  types-requests
+  types-tqdm
+  types-psutil
+  pytest
+  pydantic<=2.9.2
+commands =
+    mypy {posargs}
+
 [gh]
 python =
     3.11 = 3.11-{unitcov}


### PR DESCRIPTION
### Description of the change

Python is a dynamic language and does not use static type checking. It instead prevents typing errors at runtime . It

[mypy](https://github.com/python/mypy) is a standard open source static typing tool for Python which is widely used. This PR adds `mypy` as tox target `mypy`.

Note: The suggestions from `mypy` will be applied to the files in a follow PR and static checking enabled in CI/CD by default.

### Related issue number

Partial #33 

### How to verify the PR

Running it: `tox -e mypy`

### Was the PR tested

- [x] I have ensured all unit tests pass