### PR TITLE
[utils] check if folder exists before attempting to create directory

### DIFF
--- a/fms_mo/utils/calib_data.py
+++ b/fms_mo/utils/calib_data.py
@@ -399,7 +399,8 @@ def get_tokenized_data(
     if path_to_save:
         datasets.Dataset.from_list(traindataset).save_to_disk(path_to_save + "_train")
         if isinstance(testdataset, BatchEncoding):
-            os.mkdir(path_to_save + "_test")
+            if not os.path.exists(path_to_save + "_test"):
+                os.mkdir(path_to_save + "_test")
             torch.save(testdataset, path_to_save + "_test/testdataset.pt")
         elif isinstance(testdataset, list):
             datasets.Dataset.from_list(testdataset).save_to_disk(path_to_save + "_test")


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

Checks for directory prior to creation. This means if the folder exists, it won't error out and will simply write to the existing folder.

### Was the PR tested

created directory with same name and ran the DQ_SQ script example to verify that it was able to run without error.
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [x ] I have ensured all unit tests pass