### PR TITLE
feat: improve transformers tracing for last layers

### DIFF
--- a/fms_mo/fx/dynamo_utils.py
+++ b/fms_mo/fx/dynamo_utils.py
@@ -1117,7 +1117,7 @@ def model_analyzer(
             h.remove()
 
         # only add last layer
-        qcfg["qskip_layer_name"] += qcfg["mod_call_seq"][-1]
+        qcfg["qskip_layer_name"] += [qcfg["mod_call_seq"][-1]]
 
     with torch.no_grad():
         model_opt = torch.compile(

--- a/fms_mo/training_args.py
+++ b/fms_mo/training_args.py
@@ -56,11 +56,12 @@ class ModelArguments(TypeChecker):
 
     model_name_or_path: str = field(default="facebook/opt-125m")
     torch_dtype: str = field(default="bfloat16")
-    low_cpu_mem_usage: bool = field(
-        default=False,
+    device_map: Optional[str] = field(
+        default=None,
         metadata={
-            "help": "When set to True, leverage device_map='auto' and let HF to move modules"
-            "between cpu and cuda automatically during inference."
+            "help": "can be 'auto', 'balanced', 'balanced_low_0', 'sequential' or something like"
+            " {'encoder':'cuda:1', 'decoder': 'cuda:2'}.\n"
+            "HF will try to move modules between cpu and cuda automatically during inference."
         },
     )
     use_fast_tokenizer: bool = field(


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

When graph breaks happen, last layer cannot be determined accurately in model_analyzer(), i.e. dynamo option. An simpler but limited approach is introduced to address this issue. Currently only enabled for transformers, as 1. transformers often run into graph break, and 2. usually transformers do not have parallel heads at the end.

### Related issue number

Issue #71 

### How to verify the PR

If user wants to force last layer to be quantized, it can be done through `qcfg["qspecial_layers"]`, such as `qcfg["qspecial_layers"] = {'lm_head':{'nbits_w':8,'qw_mode':'sawb+','nbits_a':8,'qa_mode':'pact+'}}`

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [X] I have ensured all unit tests pass