### PR TITLE
Change gh-action-pypi to v1.12.4

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -77,7 +77,7 @@ jobs:
                   path: dist
 
             - name: Upload to Test PyPI
-              uses: pypa/gh-action-pypi-publish@15c56dba361d8335944d31a2ecd17d700fc7bcbc # v1.12.2
+              uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
               with:
                   repository-url: https://test.pypi.org/legacy/
 


### PR DESCRIPTION
### Description of the change

Changed the github action gh/gh-action-pypi-publish to v1.12.4.  There appears to be a bug in the metadata in our current github action version (v1.12.2) that was resolved in v1.12.3.  This was causing our automatic builds to not be published to pypi.

Versions for github actions are done by "@commit_hash" for safety.  The commit hash changed is pointing to the version for 1.12.4: 76f52bc884231f62b9a034ebfe128415bbaabdfc

https://github.com/pypa/gh-action-pypi-publish/commit/76f52bc884231f62b9a034ebfe128415bbaabdfc

### How to verify the PR

I can't test the PR locally.  We will have to see how it works in CI/CD.