### PR TITLE
feat: Update syntax of custom torch ops

### DIFF
--- a/fms_mo/aiu_addons/gptq/gptq_aiu_op.py
+++ b/fms_mo/aiu_addons/gptq/gptq_aiu_op.py
@@ -42,7 +42,7 @@ def register_op_decorator(pt_ver, op_namespace_id):
     """Version-dependent decorator for custom op registration."""
 
     def decorator(func):
-        if pt_ver <= Version("2.4"):
+        if pt_ver < Version("2.4"):
             return torch.library.impl_abstract(op_namespace_id)(func)
         return torch.library.register_fake(op_namespace_id)(func)
 
@@ -61,7 +61,7 @@ def register_aiu_gptq_op():
         logger.warning("AIU op has already been registered")
         return
     op_namespace_id = "gptq_gemm::i4f16_fxinputs_aiu"
-    if torch_version <= Version("2.4"):
+    if torch_version < Version("2.4"):
         torch.library.define(
             op_namespace_id,
             "(Tensor x, Tensor qw, Tensor qzeros, "

--- a/fms_mo/aiu_addons/gptq/gptq_aiu_op.py
+++ b/fms_mo/aiu_addons/gptq/gptq_aiu_op.py
@@ -17,12 +17,36 @@
 import logging
 
 # Third Party
+from packaging.version import Version
 import torch
 
 # pylint: disable=unused-argument
 # gptq op must be registered with specific I/O, even if not in use by the op function
 
 logger = logging.getLogger(__name__)
+torch_version = Version(torch.__version__.split("+", maxsplit=1)[0])
+
+
+def implement_op_decorator(pt_ver, op_namespace_id):
+    """Version-dependent decorator for custom op implementation."""
+
+    def decorator(func):
+        if pt_ver < Version("2.4"):
+            return torch.library.impl(op_namespace_id, "default")(func)
+        return torch.library.custom_op(op_namespace_id, mutates_args=())(func)
+
+    return decorator
+
+
+def register_op_decorator(pt_ver, op_namespace_id):
+    """Version-dependent decorator for custom op registration."""
+
+    def decorator(func):
+        if pt_ver <= Version("2.4"):
+            return torch.library.impl_abstract(op_namespace_id)(func)
+        return torch.library.register_fake(op_namespace_id)(func)
+
+    return decorator
 
 
 def register_aiu_gptq_op():
@@ -37,9 +61,15 @@ def register_aiu_gptq_op():
         logger.warning("AIU op has already been registered")
         return
     op_namespace_id = "gptq_gemm::i4f16_fxinputs_aiu"
+    if torch_version <= Version("2.4"):
+        torch.library.define(
+            op_namespace_id,
+            "(Tensor x, Tensor qw, Tensor qzeros, "
+            "Tensor scales, Tensor g_idx) -> Tensor",
+        )
 
     # Add implementations for the operator
-    @torch.library.custom_op(op_namespace_id, mutates_args=())
+    @implement_op_decorator(torch_version, op_namespace_id)
     def i4f16_fxinputs_aiu(
         x: torch.Tensor,
         qw: torch.Tensor,
@@ -66,7 +96,7 @@ def register_aiu_gptq_op():
         )
         return output.view(outshape)
 
-    @torch.library.register_fake(op_namespace_id)
+    @register_op_decorator(torch_version, op_namespace_id)
     def _(x, qw, qzeros, scales, g_idx):
         """OP template of I/O sizes"""
 

--- a/fms_mo/aiu_addons/i8i8/i8i8_aiu_op.py
+++ b/fms_mo/aiu_addons/i8i8/i8i8_aiu_op.py
@@ -66,7 +66,7 @@ def register_aiu_i8i8_op():
         logger.warning("AIU op has already been registered")
         return
     op_namespace_id = "fms_mo::i8i8_aiu"
-    if torch_version <= Version("2.4"):
+    if torch_version < Version("2.4"):
         torch.library.define(
             op_namespace_id,
             "(Tensor x, Tensor weight, Tensor bias, Tensor qdata, "

--- a/fms_mo/aiu_addons/i8i8/i8i8_aiu_op.py
+++ b/fms_mo/aiu_addons/i8i8/i8i8_aiu_op.py
@@ -36,7 +36,7 @@ def implement_op_decorator(pt_ver, op_namespace_id):
     """Version-dependent decorator for custom op implementation."""
 
     def decorator(func):
-        if pt_ver <= Version("2.4"):
+        if pt_ver < Version("2.4"):
             return torch.library.impl(op_namespace_id, "default")(func)
         return torch.library.custom_op(op_namespace_id, mutates_args=())(func)
 
@@ -47,7 +47,7 @@ def register_op_decorator(pt_ver, op_namespace_id):
     """Version-dependent decorator for custom op registration."""
 
     def decorator(func):
-        if pt_ver <= Version("2.4"):
+        if pt_ver < Version("2.4"):
             return torch.library.impl_abstract(op_namespace_id)(func)
         return torch.library.register_fake(op_namespace_id)(func)
 

--- a/fms_mo/aiu_addons/i8i8/i8i8_aiu_op.py
+++ b/fms_mo/aiu_addons/i8i8/i8i8_aiu_op.py
@@ -17,10 +17,9 @@
 import logging
 
 # Third Party
+from packaging.version import Version
 import torch
 import torch.nn.functional as F
-
-logger = logging.getLogger(__name__)
 
 # pylint: disable=unused-argument
 # i8i8 op must be registered with specific I/O, even if not in use by the op function
@@ -28,6 +27,31 @@ logger = logging.getLogger(__name__)
 # pylint: disable=not-callable
 # torch.nn.functional.linear not recognized as callable
 # open issue in PyLint: https://github.com/pytorch/pytorch/issues/119482
+
+logger = logging.getLogger(__name__)
+torch_version = Version(torch.__version__.split("+", maxsplit=1)[0])
+
+
+def implement_op_decorator(pt_ver, op_namespace_id):
+    """Version-dependent decorator for custom op implementation."""
+
+    def decorator(func):
+        if pt_ver <= Version("2.4"):
+            return torch.library.impl(op_namespace_id, "default")(func)
+        return torch.library.custom_op(op_namespace_id, mutates_args=())(func)
+
+    return decorator
+
+
+def register_op_decorator(pt_ver, op_namespace_id):
+    """Version-dependent decorator for custom op registration."""
+
+    def decorator(func):
+        if pt_ver <= Version("2.4"):
+            return torch.library.impl_abstract(op_namespace_id)(func)
+        return torch.library.register_fake(op_namespace_id)(func)
+
+    return decorator
 
 
 def register_aiu_i8i8_op():
@@ -42,8 +66,16 @@ def register_aiu_i8i8_op():
         logger.warning("AIU op has already been registered")
         return
     op_namespace_id = "fms_mo::i8i8_aiu"
+    if torch_version <= Version("2.4"):
+        torch.library.define(
+            op_namespace_id,
+            "(Tensor x, Tensor weight, Tensor bias, Tensor qdata, "
+            "str weight_quant_type, str activ_quant_type, "
+            "bool smoothquant) "
+            "-> Tensor",
+        )
 
-    @torch.library.custom_op(op_namespace_id, mutates_args=())
+    @implement_op_decorator(torch_version, op_namespace_id)
     def i8i8_aiu(
         x: torch.Tensor,
         weight: torch.Tensor,
@@ -78,7 +110,7 @@ def register_aiu_i8i8_op():
 
         return F.linear(x_dq.to(dtype), w_dq.to(dtype), bias.to(dtype))
 
-    @torch.library.register_fake(op_namespace_id)
+    @register_op_decorator(torch_version, op_namespace_id)
     def _(x, weight, bias, qdata, weight_quant_type, activ_quant_type, smoothquant):
         """OP template of I/O sizes"""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
 "numpy>=1.26.4,<2.3.0",
 "accelerate>=0.20.3,!=0.34,<1.7",
 "transformers>=4.45,<4.51",
-"torch>=2.2.0,<2.6", 
+"torch>=2.4,<2.6",
 "triton>=3.0,<3.2",
 "tqdm>=4.66.2,<5.0",
 "datasets>=3.0.0,<4.0",


### PR DESCRIPTION
### Description of the change

This PR updates the syntax of registration of a custom op with pytorch. The purpose of registration is to create a custom operation that can be inserted as custom node in the computational graph without inducing a graph break.

From PyTorch 2.4, new `torch.library` functions have been introduced: 
- `custom_op` replacing `impl`
- `register_fake` replacing `impl_abstract`
They streamline earlier implementations of the custom op registration process. With the new syntax, there is no need for an additional op definition using `torch.library.define`. 

The earlier syntax is deprecated from PyTorch >= 2.6: `impl_abstract` redirects to `register_fake` and throws a warning.
However, the new functions introduce a severe lower bound to `fms-mo`-supported PyTorch versions (>= 2.4), so we may want to hold to this update until later on.

### Was the PR tested

- [X] I have ensured all unit tests pass