### PR TITLE
feat: trimming config save

### DIFF
--- a/fms_mo/utils/qconfig_utils.py
+++ b/fms_mo/utils/qconfig_utils.py
@@ -16,6 +16,7 @@
 # Standard
 from copy import deepcopy
 from datetime import date
+from importlib.metadata import version
 from pathlib import Path
 from typing import Any
 import json
@@ -26,7 +27,6 @@ import warnings
 
 # Third Party
 from torch import nn
-import pkg_resources
 import torch
 
 # Local
@@ -56,7 +56,7 @@ def get_pkg_info(other_pkgs: list = None) -> dict:
     # Get installed packages name:version
     pkgs.update(
         {
-            pkg: pkg_resources.get_distribution(pkg).version
+            pkg: version(pkg)
             for pkg in [
                 "fms-model-optimizer",
                 "torch",

--- a/fms_mo/utils/qconfig_utils.py
+++ b/fms_mo/utils/qconfig_utils.py
@@ -414,7 +414,7 @@ def serialize_config(config):
     return config, dump
 
 
-def remove_unwanted_from_config(config, minimal:bool=False):
+def remove_unwanted_from_config(config, minimal:bool=True):
     """Remove deprecated items or things cannot be saved as text (json)"""
     unwanted_items = [
         "sweep_cv_percentile",

--- a/fms_mo/utils/qconfig_utils.py
+++ b/fms_mo/utils/qconfig_utils.py
@@ -170,7 +170,7 @@ def find_recipe_json(recipe: str, subdir: str = None) -> Path:
         subdir (str, optional): Alternative subdir path from pkg_root. Defaults to None.
 
     Returns:
-        Path: Path to recipe .json if found, else None
+        Path: File Path to .json recipe if found, else None
     """
     if recipe is None:
         return None

--- a/fms_mo/utils/qconfig_utils.py
+++ b/fms_mo/utils/qconfig_utils.py
@@ -528,7 +528,7 @@ def add_wanted_defaults_to_config(config, minimal: bool = True):
     if a wanted item is not in the config, add it w/ default value
     """
     if not minimal:
-        config.update( config_defaults() )
+        config.update(config_defaults())
 
 
 def qconfig_save(

--- a/fms_mo/utils/qconfig_utils.py
+++ b/fms_mo/utils/qconfig_utils.py
@@ -220,46 +220,43 @@ def get_recipe(recipe: str, subdir: str = None) -> Any:
 
 def qconfig_init(recipe: str = None, args: Any = None) -> dict:
     """Three possible ways to create qcfg:
-    1. create a default qcfg
-    2. load from a json
-    3. parse the args
-    NOTE: Content from higher number, e.g. arg parser, will override thier counterpart from lower
-            numbers, e.g. json.
+        1. create a default qcfg
+        2. load from a json
+        3. parse the args
+        NOTE: Content from higher number, e.g. arg parser, will override thier counterpart from
+            lower numbers, e.g. json.
 
     Args:
-    recipe: str. Recipe filename (json) that contains settings, if specified and exists. Will search
-            cwd and fms_mo/recipes folder. ok to omit '.json' extension.
-    args: argparser object that may contain relavant parameters.
+        recipe: str. Recipe filename (json) that contains settings, if specified and exists.
+            Will search cwd and fms_mo/recipes folder. ok to omit '.json' extension.
+        args: argparser object that may contain relevant parameters.
 
-    Important items in the config dictionary:
-    nbits_[w|a]_alt: "_alt" stands for "alternative" -> the default prec for those "skipped" layers
-                        e.g. usually the 1st/last layers are "skipped" and will NOT be swapped to
-                        QLinear. But, if "nbits_x_alt = 8", they will.
-    qmodel_calibration[_new]: set to non-zero will trigger calibration. "_new" means calibration
-                                will happen during the first N calls of fwd path, better for long
-                                training or fine-tuning that you don't mind losing the first N iters
-
-    qlayer_name_pattern: allows partial or regex name matching, the layers satisfy the criteria will
-                        be skipped. NOTE: tracing will be bypassed entirely if this arg is used
-    qskip_layer_name: user can specify exact name to skip
-    qspecial_layers: special case handling. user can specify any quant params for any given layer,
-                     e.g. {'1st.conv':{'nbits_w':8,'qw_mode':'pact+sym'}, '2nd.layers':{...} }
-
-    extend_act_range: symmetric act quantizers (maxsym, pactsym+, ...) to use full range, e.g.,
-                      [-128, 127] instead [-127,127], TODO: should default to True?
-
-    ptq_nbatch: total number of batches of data that will be fetched from loader for PTQ tuning
-    ptq_batchsize: data used in PTQ tuning usually is fetched from loader directly, i.e. batchsize
-                    is the unchanged from dataloader.batch_size. although it could be different if
-                    needed, e.g. PTQ may allow larger bs due to only partial model tuning. But fine-
-                    grain shuffling will be needed in that case.
-    ptq_nouterloop: number of optimization "steps" in the PTQ outer loop. 1 outer loop uses 1 cached
-                    data batch. when Nouter >= Nbatch, data will be re-used
-    ptq_ninnerloop: number of "inner loop" for PTQ optimization. When 1 batch of data is fetched,
-                    run (loss->loss.back->optim.step) this many times before fetching the next batch
-                    NOTE: usually doesn't make big differences, hence, default to 1
-    ptq_coslr: can be "", "W" or "A" or "WA", indicating which (or both) optimizer will use cosLR,
-                otherwise use constantLR as default
+        Important items in the config dictionary:
+        nbits_[w|a]_alt: "_alt" stands for "alternative" -> the default prec for those "skipped"
+            layers e.g. usually the 1st/last layers are "skipped" and will NOT be swapped to
+            QLinear. But, if "nbits_x_alt = 8", they will.
+        qmodel_calibration[_new]: set to non-zero will trigger calibration. "_new" means
+            calibration will happen during the first N calls of fwd path, better for long
+            training or fine-tuning that you don't mind losing the first N iters
+        qlayer_name_pattern: allows partial or regex name matching, the layers satisfy the
+            criteria will be skipped. NOTE: tracing will be bypassed entirely if this arg is used
+        qskip_layer_name: user can specify exact name to skip
+        qspecial_layers: special case handling. user can specify any quant params for any
+            given layer, e.g. {'1st.conv':{'nbits_w':8,'qw_mode':'pact+sym'}, '2nd.layers':{...} }
+        extend_act_range: symmetric act quantizers (maxsym, pactsym+, ...) to use full range, e.g.,
+            [-128, 127] instead [-127,127], TODO: should default to True?
+        ptq_nbatch: total number of batches of data that will be fetched from loader for PTQ tuning
+        ptq_batchsize: data used in PTQ tuning usually is fetched from loader directly,
+            i.e. batchsize is the unchanged from dataloader.batch_size. although it could be
+            different if needed, e.g. PTQ may allow larger bs due to only partial model tuning.
+            But fine-grain shuffling will be needed in that case.
+        ptq_nouterloop: number of optimization "steps" in the PTQ outer loop. 1 outer loop uses
+            1 cached data batch. when Nouter >= Nbatch, data will be re-used
+        ptq_ninnerloop: number of "inner loop" for PTQ optimization. When 1 batch of data is
+            fetched, run (loss->loss.back->optim.step) this many times before fetching the next
+            batch. NOTE: usually doesn't make big differences, hence, default to 1
+        ptq_coslr: can be "", "W" or "A" or "WA", indicating which (or both) optimizer will use
+            cosLR, otherwise use constantLR as default
     """
 
     qcfg = {}
@@ -379,7 +376,7 @@ def qconfig_init(recipe: str = None, args: Any = None) -> dict:
         temp_cfg = get_recipe(recipe)
         if temp_cfg:
             qcfg.update(temp_cfg)
-            logger.info("Updated config w/ recipe values")
+            logger.info("Updated config with recipe values")
         else:
             raise ValueError(f"Config recipe {recipe} was not found.")
 
@@ -406,7 +403,7 @@ def qconfig_init(recipe: str = None, args: Any = None) -> dict:
 def has_non_serializable_object(anything: Any) -> bool:
     """
     Generalized recursive function looking for any non-serializable Python object
-    Only types that are JSON serializable are None, primatives, tuples, lists, and dicts.
+    Only types that are JSON serializable are None, primitives, tuples, lists, and dicts.
     Any other types must be converted into one of the types above.
     """
     if isinstance(anything, (list, tuple)):
@@ -468,7 +465,7 @@ def remove_unwanted_from_config(config: dict, minimal: bool = True):
         "checkQerr_frequency",
         "newlySwappedModules",
         "force_calib_once",
-        # if we keep the follwing LUTs, it will save the entire model
+        # if we keep the following LUTs, it will save the entire model
         "LUTmodule_name",
         "qkvsync_my_1st_sibling",
         "graph_in_out",

--- a/fms_mo/utils/qconfig_utils.py
+++ b/fms_mo/utils/qconfig_utils.py
@@ -194,6 +194,16 @@ def find_recipe_json(recipe: str, subdir: str = None):
 
 
 def get_recipe(recipe: str, subdir: str = None):
+    """
+    Get a json recipe.
+
+    Args:
+        recipe (str): Name of the recipe file.
+        subdir (str, optional): A subdirectory to search from root. Defaults to None.
+
+    Returns:
+        Any: Data from a saved .json.
+    """
     json_file = find_recipe_json(recipe, subdir)
 
     temp_data = None
@@ -366,7 +376,7 @@ def qconfig_init(recipe: str = None, args: Any = None):
         temp_cfg = get_recipe(recipe)
         if temp_cfg:
             qcfg.update(temp_cfg)
-            logger.info(f"Updated config w/ recipe values")
+            logger.info("Updated config w/ recipe values")
         else:
             raise ValueError(f"Config recipe {recipe} was not found.")
 
@@ -518,10 +528,7 @@ def add_wanted_defaults_to_config(config, minimal: bool = True):
     if a wanted item is not in the config, add it w/ default value
     """
     if not minimal:
-        wanted_items = config_defaults()
-        for wanted_name, wanted_default_val in wanted_items.items():
-            if wanted_name not in config:
-                config[wanted_name] = wanted_default_val
+        config.update( config_defaults() )
 
 
 def qconfig_save(

--- a/fms_mo/utils/qconfig_utils.py
+++ b/fms_mo/utils/qconfig_utils.py
@@ -172,6 +172,9 @@ def find_recipe_json(recipe: str, subdir: str = None) -> Path:
     Returns:
         Path: Path to recipe .json if found, else None
     """
+    if recipe is None:
+        return None
+
     cwd = Path().resolve()
     pkg_root = Path(__file__).parent.parent.resolve()
     file_in_cwd = cwd / recipe
@@ -477,7 +480,7 @@ def remove_unwanted_from_config(config: dict, minimal: bool = True):
         default_config = config_defaults()
         for key, val in config.items():
             # If config has a default setting, add to unwanted items
-            if key in default_config and default_config.get(key) == val:
+            if default_config.get(key) == val:
                 unwanted_items.append(key)
 
     len_before = len(config)
@@ -533,7 +536,7 @@ def add_wanted_defaults_to_config(config: dict, minimal: bool = True) -> None:
 
 def qconfig_save(
     qcfg: dict,
-    recipe: str = "keys_to_save",
+    recipe: str = None,
     minimal: bool = True,
     fname="qcfg.json",
 ) -> None:
@@ -551,21 +554,21 @@ def qconfig_save(
 
     # First check in qcfg for added save list
     # This value is hardcoded to avoid probing qcfg with real keys like "qa_mode"
-    recipe_items = qcfg.get("keys_to_save", [])
+    keys_to_save = qcfg.get("keys_to_save", [])
 
     # Next, check in fms_mo/recipes and merge them into a unique set (in case they differ)
-    recipe_items_json = get_recipe(recipe)
-    if recipe_items_json:
-        recipe_items = list(set(recipe_items + recipe_items_json))
+    keys_to_save_json = get_recipe(recipe)
+    if keys_to_save_json:
+        keys_to_save = list(set(keys_to_save + keys_to_save_json))
 
-    # If we found recipe items to add, fetch them from qcfg
-    if recipe_items:
+    # If we found keys to save, fetch them from qcfg
+    if keys_to_save:
         temp_qcfg = {}
-        for key in recipe_items:
+        for key in keys_to_save:
             if key in qcfg:
                 temp_qcfg[key] = qcfg[key]
             else:
-                raise ValueError(f"Desired save recipe {key=} not in qcfg!")
+                raise ValueError(f"Desired save {key=} not in qcfg!")
 
     else:
         # We assume a full qcfg is being saved - trim it!

--- a/fms_mo/utils/qconfig_utils.py
+++ b/fms_mo/utils/qconfig_utils.py
@@ -435,7 +435,7 @@ def has_non_serializable_object(anything: Any) -> bool:
     return is_not_serializable
 
 
-def serialize_config(config: dict):
+def serialize_config(config: dict) -> tuple[dict, dict]:
     """
     Util function to clean config of any non-serializable key,val pairs
     """
@@ -458,7 +458,9 @@ def serialize_config(config: dict):
     return config, dump
 
 
-def remove_unwanted_from_config(config: dict, minimal: bool = True):
+def remove_unwanted_from_config(
+    config: dict, minimal: bool = True
+) -> tuple[dict, dict]:
     """Remove deprecated items or things cannot be saved as text (json)"""
     unwanted_items = [
         "sweep_cv_percentile",

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -814,10 +814,10 @@ def save_list(request):
     """
     return request.param
 
-bad_recipe_params = ["qat_int7", "pzq_int8"]
+wrong_recipe_name_params = ["qat_int7", "pzq_int8"]
 
-@pytest.fixture(scope="session", params=bad_recipe_params)
-def bad_recipe(request):
+@pytest.fixture(scope="session", params=wrong_recipe_name_params)
+def wrong_recipe_name(request):
     """
     Get a bad recipe json file name in fms_mo/recipes
 

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -655,12 +655,12 @@ def model_half(request):
 ###################################
 sample_input_fp32_params = [
     torch.randn(1, 3, 3, 3),
-    torch.zeros(1, 3, 3, 3),
+    torch.randn(1, 3, 3, 3)*.001,
     torch.ones(1, 3, 3, 3),
 ]
 sample_input_fp16_params = [
     torch.randn(1, 3, 3, 3).half(),
-    torch.zeros(1, 3, 3, 3).half(),
+    (torch.randn(1, 3, 3, 3)*.001).half(),
     torch.ones(1, 3, 3, 3).half(),
 ]
 

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -798,10 +798,10 @@ def config_fp16(request):
     qconfig["nbits_w"] = 16
     return qconfig
 
-save_list_params = [
+keys_to_save_params = [
     ["qa_mode", "qw_mode", "nbits_a", "nbits_w", "qskip_layer_name"],
 ]
-@pytest.fixture(scope="session", params=save_list_params)
+@pytest.fixture(scope="session", params=keys_to_save_params)
 def save_list(request):
     """
     Generate a save list for testing user-requested save config.

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -798,6 +798,36 @@ def config_fp16(request):
     qconfig["nbits_w"] = 16
     return qconfig
 
+save_list_params = [
+    ["qa_mode", "qw_mode", "nbits_a", "nbits_w", "qskip_layer_name"],
+]
+@pytest.fixture(scope="session", params=save_list_params)
+def save_list(request):
+    """
+    Generate a save list for testing user-requested save config.
+
+    Args:
+        request (list): List of variables to save in a quantized config.
+
+    Returns:
+        list: List of variables to save in a quantized config.
+    """
+    return request.param
+
+bad_recipe_params = ["qat_int7", "pzq_int8"]
+
+@pytest.fixture(scope="session", params=bad_recipe_params)
+def bad_recipe(request):
+    """
+    Get a bad recipe json file name in fms_mo/recipes
+
+    Args:
+        request (str): Bad recipe name in fms_mo/recipes
+
+    Returns:
+        str: Bad recipe name
+    """
+    return request.param
 
 # Create QAT/PTQ int8 config fixture.
 config_params = ["qat_int8", "ptq_int8"]

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -923,7 +923,7 @@ def bad_pair(request):
 
 wanted_pair_params = [
     ("nbits_a", 32),
-    ("qw_mode", "sawb"),
+    ("qw_mode", "sawb+"),
     ("extend_act_range", False),
     ("qspecial_layers", {}),
 ]

--- a/tests/models/test_model_utils.py
+++ b/tests/models/test_model_utils.py
@@ -173,6 +173,16 @@ def load_json(file_path: str = "qcfg.json"):
     assert json_file is not None, f"JSON at {file_path} was not found"
     return json_file
 
+def save_json(data, file_path: str = "qcfg.json"):
+    """
+    Save data object to json file
+
+    Args:
+        data (_type_): _description_
+        file_path (str, optional): _description_. Defaults to "qcfg.json".
+    """
+    with open(file_path, "w", encoding="utf-8") as outfile:
+        json.dump(data, outfile, indent=4)
 
 def save_serialized_json(config: dict, file_path: str = "qcfg.json"):
     """
@@ -189,5 +199,4 @@ def save_serialized_json(config: dict, file_path: str = "qcfg.json"):
             del config[key]
 
     serialize_config(config)  # Only remove stuff necessary to dump
-    with open(file_path, "w", encoding="utf-8") as outfile:
-        json.dump(config, outfile, indent=4)
+    save_json(config, file_path)

--- a/tests/models/test_qmodelprep.py
+++ b/tests/models/test_qmodelprep.py
@@ -24,7 +24,7 @@ import transformers
 
 # Local
 # fms_mo imports
-from fms_mo import qmodel_prep
+from fms_mo import qconfig_init, qmodel_prep
 from fms_mo.prep import has_quantized_module
 from fms_mo.utils.utils import patch_torch_bmm
 from tests.models.test_model_utils import count_qmodules, delete_config, qmodule_error
@@ -52,6 +52,18 @@ if torch.cuda.is_available():
         delete_config()
         with pytest.raises(RuntimeError):
             qmodel_prep(model_quantized, sample_input_fp32, config_fp32)
+
+def test_bad_recipe(
+    bad_recipe: str,
+):
+    """
+    Test if giving a bad recipe .json file name results in a ValueError.
+
+    Args:
+        bad_recipe (str): Bad .json file name
+    """
+    with pytest.raises(ValueError):
+        qconfig_init(recipe=bad_recipe)
 
 
 def test_double_qmodel_prep_assert(

--- a/tests/models/test_qmodelprep.py
+++ b/tests/models/test_qmodelprep.py
@@ -53,17 +53,17 @@ if torch.cuda.is_available():
         with pytest.raises(RuntimeError):
             qmodel_prep(model_quantized, sample_input_fp32, config_fp32)
 
-def test_bad_recipe(
-    bad_recipe: str,
+def test_recipe_not_present(
+    wrong_recipe_name: str,
 ):
     """
     Test if giving a bad recipe .json file name results in a ValueError.
 
     Args:
-        bad_recipe (str): Bad .json file name
+        wrong_recipe_name (str): Wrong .json file name
     """
     with pytest.raises(ValueError):
-        qconfig_init(recipe=bad_recipe)
+        qconfig_init(recipe=wrong_recipe_name)
 
 
 def test_double_qmodel_prep_assert(

--- a/tests/models/test_saveconfig.py
+++ b/tests/models/test_saveconfig.py
@@ -99,7 +99,7 @@ def test_save_config_with_qcfg_save(
     config_fp32["save"] = save_list
 
     qconfig_save(config_fp32, minimal=False)
-    
+
     loaded_config = load_json()
 
     # Remove pkg_versions and date before processing
@@ -136,10 +136,10 @@ def test_save_config_with_recipe_save(
     save_json(save_list, file_path=save_path)
 
     qconfig_save(config_fp32, recipe="save_list")
-    
+
     # Check that saved qcfg matches
     loaded_config = load_json()
-    
+
     # Remove pkg_versions and date before processing
     del loaded_config["pkg_versions"]
     del loaded_config["date"]
@@ -157,6 +157,12 @@ def test_save_config_with_recipe_save(
 def test_save_config_minimal(
     config_fp32: dict,
 ):
+    """
+    Test for checking that the minimal functionality works for saving a quantized config.
+
+    Args:
+        config_fp32 (dict): Config for fp32 quantization
+    """
     delete_config()
 
     qconfig_save(config_fp32, minimal=True)

--- a/tests/models/test_saveconfig.py
+++ b/tests/models/test_saveconfig.py
@@ -96,7 +96,7 @@ def test_save_config_with_qcfg_save(
         save_list (list): List of variables to save in a quantized config.
     """
     delete_config()
-    config_fp32["save"] = save_list
+    config_fp32["keys_to_save"] = save_list
 
     qconfig_save(config_fp32, minimal=False)
 
@@ -114,7 +114,7 @@ def test_save_config_with_qcfg_save(
         assert loaded_config.get(key) == config_fp32.get(key)
 
     delete_config()
-    del config_fp32["save"]
+    del config_fp32["keys_to_save"]
 
 def test_save_config_with_recipe_save(
     config_fp32: dict,
@@ -129,13 +129,13 @@ def test_save_config_with_recipe_save(
     """
     # Delete both qcfg and the save.json before starting
     delete_config()
-    delete_config("save.json")
+    delete_config("keys_to_save.json")
 
     # Save new "save.json"
-    save_path = "save_list.json"
+    save_path = "keys_to_save.json"
     save_json(save_list, file_path=save_path)
 
-    qconfig_save(config_fp32, recipe="save_list")
+    qconfig_save(config_fp32, recipe="keys_to_save")
 
     # Check that saved qcfg matches
     loaded_config = load_json()
@@ -152,7 +152,7 @@ def test_save_config_with_recipe_save(
         assert loaded_config.get(key) == config_fp32.get(key)
 
     delete_config()
-    delete_config("save.json")
+    delete_config("keys_to_save.json")
 
 def test_save_config_minimal(
     config_fp32: dict,


### PR DESCRIPTION
### Description of the change

Added the following features to the config save process:
- minimal: Only save non-default valued config entries
- save_list: Save only variables contained in qcfg["save_list"]
- recipe save_list: Same as save_list, but in .json form for long term use
- Added archival timestamp: date and pkg_versions for saved config

Furthermore, this work adds basic testing to ensure the above works.  This testing is in tests/models/test_saveconfig.py, as well as supporting files.

TODO List:

- Audit all current config variables to ensure they are grouped with prefixes if needed
- Fix pylint errors

### Related issue number

Addresses #97

### How to verify the PR

Run tests/models/ pytest

### Was the PR tested

- I have added >=1 unit test(s) for every new method I have added.
- I have ensured all unit tests pass