### PR TITLE
feat: Conversion example

### DIFF
--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -3,6 +3,8 @@ acc
 ADR
 aiu
 AIU
+Spyre
+spyre
 Args
 AutoGPTQ
 autoregressive

--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -1,6 +1,8 @@
 activations
 acc
 ADR
+aiu
+AIU
 Args
 AutoGPTQ
 autoregressive
@@ -91,8 +93,11 @@ quantizes
 Quantizing
 QW
 rceil
+recomputation
 repo
 representable
+roberta
+RoBERTa
 runtime
 Runtime
 SAWB
@@ -112,9 +117,9 @@ Tokenizer
 toml
 triton
 Unquantized
+utils
 vals
 venv
 vllm
 xs
 zp
-

--- a/examples/AIU_CONVERSION/README.md
+++ b/examples/AIU_CONVERSION/README.md
@@ -1,8 +1,11 @@
 # Train and prepare INT8 checkpoint for the AIU using Direct Quantization
-This example builds on the [Direct Quantization (DQ) example](../DQ_SQ/README.md). We assume the user is already familiar with the DQ quantization process and would like to generate an INT8-quantized checkpoint that is made compliant with the requirements of the AIU.
+This example builds on the [Direct Quantization (DQ) example](../DQ_SQ/README.md). We assume the user is already familiar with the DQ quantization process and would like to generate an INT8-quantized checkpoint that is made compliant with the requirements of the AIU/Spire accelerator.
 
 Once created, this checkpoint can be run on the AIU by using an inference script from [aiu-fms-testing-utils](https://github.com/foundation-model-stack/aiu-fms-testing-utils).
 
+For more information on the AIU/Spyre accelerator, see the following blogs:
+- [Introducing the IBM Spyre AI Accelerator chip](https://research.ibm.com/blog/spyre-for-z)
+- [IBM Power modernizes infrastructure and accelerates innovation with AI in the year ahead](https://newsroom.ibm.com/blog-ibm-power-modernizes-infrastructure-and-accelerates-innovation-with-ai-in-the-year-ahead)
 
 ## Requirements
 - [FMS Model Optimizer requirements](../../README.md#requirements)

--- a/examples/AIU_CONVERSION/README.md
+++ b/examples/AIU_CONVERSION/README.md
@@ -1,0 +1,37 @@
+# Train and prepare INT8 checkpoint for the AIU using Direct Quantization
+This example builds on the [Direct Quantization (DQ) example](../DQ_SQ/README.md). We assume the user is already familiar with the DQ quantization process and would like to generate an INT8-quantized checkpoint that is made compliant with the requirements of the AIU.
+
+Once created, this checkpoint can be run on the AIU by using an inference script from [aiu-fms-testing-utils](https://github.com/foundation-model-stack/aiu-fms-testing-utils).
+
+
+## Requirements
+- [FMS Model Optimizer requirements](../../README.md#requirements)
+
+## QuickStart
+
+**1. Prepare Data** as per DQ quantization process ([link](../DQ_SQ/README.md)). In this example, we assume the user wants to quantized RoBERTa-base model and has thus prepared the DQ data for it, stored under the folder `data_train` and `data_test`, by adapting the DQ example accordingly.
+
+**2. Apply DQ with conversion** by providing the desired quantization parameters, as well as the flags `--save_ckpt_for_aiu` and `--recompute_narrow_weights`.
+
+```bash
+python  -m fms_mo.run_quant \
+        --model_name_or_path "roberta-base" \
+        --training_data_path data_train \
+        --test_data_path data_test \
+        --torch_dtype "float16" \
+        --quant_method dq \
+        --nbits_w 8 \
+        --nbits_a 8 \
+        --nbits_kvcache 32 \
+        --qa_mode "pertokenmax"\
+        --qw_mode "maxperCh" \
+        --qmodel_calibration_new 1 \
+        --output_dir "dq_test" \
+        --save_ckpt_for_aiu \
+        --recompute_narrow_weights
+```
+> [!TIP]
+> - In this example, we are not evaluating the perplexity of the quantized model, but, if so desired, the user can add the `--eval_ppl` flag.
+> - We set a single calibration example because the quantizers in use do not need calibration: weights remain static during DQ, so a single example will initialize the quantizer correctly, and the activation quantizer `pertokenmax` will dynamically recompute the quantization range at inference time, when running on the AIU.
+
+**3. Reload checkpoint for testing**

--- a/fms_mo/run_quant.py
+++ b/fms_mo/run_quant.py
@@ -43,6 +43,7 @@ import transformers
 # Local
 from fms_mo.dq import run_dq
 from fms_mo.training_args import (
+    AIUArguments,
     DataArguments,
     FMSMOArguments,
     FP8Arguments,
@@ -67,6 +68,7 @@ def quantize(
     fms_mo_args: FMSMOArguments = None,
     gptq_args: GPTQArguments = None,
     fp8_args: FP8Arguments = None,
+    aiu_args: AIUArguments = None,
 ):
     """Main entry point to quantize a given model with a set of specified hyperparameters
 
@@ -105,7 +107,7 @@ def quantize(
             )
         run_fp8(model_args, data_args, opt_args, fp8_args)
     elif opt_args.quant_method == "dq":
-        run_dq(model_args, data_args, opt_args, fms_mo_args)
+        run_dq(model_args, data_args, opt_args, fms_mo_args, aiu_args)
     else:
         raise ValueError(
             f"{opt_args.quant_method} is not a valid quantization technique option. \
@@ -234,6 +236,7 @@ def get_parser():
             FMSMOArguments,
             GPTQArguments,
             FP8Arguments,
+            AIUArguments,
         )
     )
     return parser
@@ -270,6 +273,7 @@ def parse_arguments(parser, json_config=None):
             fms_mo_args,
             gptq_args,
             fp8_args,
+            aiu_args,
         ) = parser.parse_dict(json_config, allow_extra_keys=True)
     else:
         (
@@ -279,6 +283,7 @@ def parse_arguments(parser, json_config=None):
             fms_mo_args,
             gptq_args,
             fp8_args,
+            aiu_args,
             _,
         ) = parser.parse_args_into_dataclasses(return_remaining_strings=True)
 
@@ -293,6 +298,7 @@ def parse_arguments(parser, json_config=None):
         fms_mo_args,
         gptq_args,
         fp8_args,
+        aiu_args,
     )
 
 
@@ -311,13 +317,16 @@ def main():
             fms_mo_args,
             gptq_args,
             fp8_args,
+            aiu_args,
         ) = parse_arguments(parser, job_config)
 
         logger = set_log_level(opt_args.log_level, __name__)
 
-        logger.debug(f"Input args parsed: \nmodel_args {model_args}, data_args {data_args}, \
-                     opt_args {opt_args}, fms_mo_args {fms_mo_args}, gptq_args {gptq_args}, \
-                     fp8_args {fp8_args}")
+        logger.debug(
+            f"Input args parsed: \nmodel_args {model_args}, data_args {data_args}, "
+            f"opt_args {opt_args}, fms_mo_args {fms_mo_args}, gptq_args {gptq_args}, "
+            f"fp8_args {fp8_args}, aiu_args {aiu_args}"
+        )
     except Exception as e:  # pylint: disable=broad-except
         logger.error(traceback.format_exc())
         write_termination_log(
@@ -336,6 +345,7 @@ def main():
             fms_mo_args=fms_mo_args,
             gptq_args=gptq_args,
             fp8_args=fp8_args,
+            aiu_args=aiu_args,
         )
     except (MemoryError, OutOfMemoryError) as e:
         logger.error(traceback.format_exc())

--- a/fms_mo/run_quant.py
+++ b/fms_mo/run_quant.py
@@ -43,7 +43,6 @@ import transformers
 # Local
 from fms_mo.dq import run_dq
 from fms_mo.training_args import (
-    AIUArguments,
     DataArguments,
     FMSMOArguments,
     FP8Arguments,
@@ -68,7 +67,6 @@ def quantize(
     fms_mo_args: FMSMOArguments = None,
     gptq_args: GPTQArguments = None,
     fp8_args: FP8Arguments = None,
-    aiu_args: AIUArguments = None,
 ):
     """Main entry point to quantize a given model with a set of specified hyperparameters
 
@@ -107,7 +105,7 @@ def quantize(
             )
         run_fp8(model_args, data_args, opt_args, fp8_args)
     elif opt_args.quant_method == "dq":
-        run_dq(model_args, data_args, opt_args, fms_mo_args, aiu_args)
+        run_dq(model_args, data_args, opt_args, fms_mo_args)
     else:
         raise ValueError(
             f"{opt_args.quant_method} is not a valid quantization technique option. \
@@ -236,7 +234,6 @@ def get_parser():
             FMSMOArguments,
             GPTQArguments,
             FP8Arguments,
-            AIUArguments,
         )
     )
     return parser
@@ -273,7 +270,6 @@ def parse_arguments(parser, json_config=None):
             fms_mo_args,
             gptq_args,
             fp8_args,
-            aiu_args,
         ) = parser.parse_dict(json_config, allow_extra_keys=True)
     else:
         (
@@ -283,7 +279,6 @@ def parse_arguments(parser, json_config=None):
             fms_mo_args,
             gptq_args,
             fp8_args,
-            aiu_args,
             _,
         ) = parser.parse_args_into_dataclasses(return_remaining_strings=True)
 
@@ -298,7 +293,6 @@ def parse_arguments(parser, json_config=None):
         fms_mo_args,
         gptq_args,
         fp8_args,
-        aiu_args,
     )
 
 
@@ -317,7 +311,6 @@ def main():
             fms_mo_args,
             gptq_args,
             fp8_args,
-            aiu_args,
         ) = parse_arguments(parser, job_config)
 
         logger = set_log_level(opt_args.log_level, __name__)
@@ -325,7 +318,7 @@ def main():
         logger.debug(
             f"Input args parsed: \nmodel_args {model_args}, data_args {data_args}, "
             f"opt_args {opt_args}, fms_mo_args {fms_mo_args}, gptq_args {gptq_args}, "
-            f"fp8_args {fp8_args}, aiu_args {aiu_args}"
+            f"fp8_args {fp8_args}"
         )
     except Exception as e:  # pylint: disable=broad-except
         logger.error(traceback.format_exc())
@@ -345,7 +338,6 @@ def main():
             fms_mo_args=fms_mo_args,
             gptq_args=gptq_args,
             fp8_args=fp8_args,
-            aiu_args=aiu_args,
         )
     except (MemoryError, OutOfMemoryError) as e:
         logger.error(traceback.format_exc())

--- a/fms_mo/training_args.py
+++ b/fms_mo/training_args.py
@@ -138,6 +138,24 @@ class OptArguments(TypeChecker):
         default="INFO",
         metadata={"help": "The log level to adopt during optimization."},
     )
+    save_ckpt: bool = field(
+        default=True,
+        metadata={"help": "Save quantized checkpoint."},
+    )
+
+
+@dataclass
+class AIUArguments(TypeChecker):
+    """Dataclass for AIU-related arguments. Only apply to Direct Quantization runs."""
+
+    recompute_narrow_weights: bool = field(
+        default=False,
+        metadata={"help": "Apply recomputation during checkpoint saving."},
+    )
+    save_ckpt_for_aiu: bool = field(
+        default=False,
+        metadata={"help": "Prepare and save AIU-compliant checkpoint."},
+    )
 
 
 @dataclass

--- a/fms_mo/training_args.py
+++ b/fms_mo/training_args.py
@@ -142,16 +142,6 @@ class OptArguments(TypeChecker):
         default=True,
         metadata={"help": "Save quantized checkpoint."},
     )
-
-
-@dataclass
-class AIUArguments(TypeChecker):
-    """Dataclass for AIU-related arguments. Only apply to Direct Quantization runs."""
-
-    recompute_narrow_weights: bool = field(
-        default=False,
-        metadata={"help": "Apply recomputation during checkpoint saving."},
-    )
     save_ckpt_for_aiu: bool = field(
         default=False,
         metadata={"help": "Prepare and save AIU-compliant checkpoint."},
@@ -191,6 +181,10 @@ class FMSMOArguments(TypeChecker):
         default=2048, metadata={"help": "input sequence length after tokenization"}
     )
     eval_ppl: bool = field(default=False)
+    recompute_narrow_weights: bool = field(
+        default=False,
+        metadata={"help": "Apply recomputation during checkpoint saving for AIU."},
+    )
 
 
 @dataclass

--- a/fms_mo/utils/dq_utils.py
+++ b/fms_mo/utils/dq_utils.py
@@ -115,5 +115,15 @@ def config_quantize_smooth_layers(qcfg: dict):
             qcfg["smoothq_act_scale_path"] = "./act_scales/graniteCodeHF_34b_base12.pt"
         if "granite-34b-code-instruct" in qcfg["model"]:
             qcfg["smoothq_act_scale_path"] = "./act_scales/graniteCodeHF_34b_base12.pt"
+    elif "roberta" in qcfg["model"]:
+        qcfg["act_scale_path"] = "./act_scales"
+        qcfg["scale_layers"] = [
+            "attention.self.query",
+            "attention.self.key",
+            "attention.self.value",
+            "intermediate.dense",
+        ]
+        qcfg["qskip_layer_name"] = []
+        qcfg["qlayer_name_pattern"] = ["roberta.encoder"]
     else:
         raise ValueError("The model architecture is not supported for DQ.")

--- a/fms_mo/utils/dq_utils.py
+++ b/fms_mo/utils/dq_utils.py
@@ -117,7 +117,7 @@ def config_quantize_smooth_layers(qcfg: dict):
             qcfg["smoothq_act_scale_path"] = "./act_scales/graniteCodeHF_34b_base12.pt"
     elif "roberta" in qcfg["model"]:
         qcfg["act_scale_path"] = "./act_scales"
-        qcfg["scale_layers"] = [
+        qcfg["smoothq_scale_layers"] = [
             "attention.self.query",
             "attention.self.key",
             "attention.self.value",

--- a/fms_mo/utils/qconfig_utils.py
+++ b/fms_mo/utils/qconfig_utils.py
@@ -114,6 +114,7 @@ def config_defaults() -> dict:
         "extend_act_range": False,
         "plotsvg": False,
         "qskip_large_mag_layers": False,
+        "recompute_narrow_weights": False,
         # Iterable vars
         "qlayer_name_pattern": [],
         "qskip_layer_name": [],
@@ -306,6 +307,7 @@ def qconfig_init(recipe: str = None, args: Any = None) -> dict:
     qcfg["qlayer_name_pattern"] = []
     qcfg["qskip_layer_name"] = []
     qcfg["qskip_large_mag_layers"] = False
+    qcfg["recompute_narrow_weights"] = False
     qcfg["qspecial_layers"] = {}
 
     # settings about quantizing bmm/matmul
@@ -878,6 +880,7 @@ def check_config(config: dict, model_dtype: torch.dtype = None) -> None:
         "ptq_freezecvs",
         "ptq_qdrop",
         "qskip_large_mag_layers",
+        "recompute_narrow_weights",
         "smoothq",
     ]
     for boolean_var_str in boolean_vars_str:

--- a/tests/test_run_quant.py
+++ b/tests/test_run_quant.py
@@ -110,7 +110,6 @@ def test_parse_arguments(job_config):
         _,
         _,
         _,
-        _,
     ) = parse_arguments(parser, job_config_copy)
     assert str(model_args.torch_dtype) == "torch.bfloat16"
     assert data_args.training_data_path == "data_train"
@@ -131,7 +130,6 @@ def test_parse_arguments_defaults(job_config):
         data_args,
         _,
         fms_mo_args,
-        _,
         _,
         _,
     ) = parse_arguments(parser, job_config_defaults)

--- a/tests/test_run_quant.py
+++ b/tests/test_run_quant.py
@@ -110,6 +110,7 @@ def test_parse_arguments(job_config):
         _,
         _,
         _,
+        _,
     ) = parse_arguments(parser, job_config_copy)
     assert str(model_args.torch_dtype) == "torch.bfloat16"
     assert data_args.training_data_path == "data_train"
@@ -130,6 +131,7 @@ def test_parse_arguments_defaults(job_config):
         data_args,
         _,
         fms_mo_args,
+        _,
         _,
         _,
     ) = parse_arguments(parser, job_config_defaults)


### PR DESCRIPTION
### Description of the change

Add example of converting and saving the checkpoint of RoBERTa INT8 model after DQ.
In addition, as part of this PR:
- support is added for RoBERTa architecture to run DQ with smoothquant, by initializing `smoothq_scale_layers` and other quantization parameters
- 3 training arguments are added: `save_ckpt`, `save_ckpt_for_aiu`, and `recompute_narrow_weights`
- smoothquant selection is modified from being always enabled in DQ (`qcfg["smoothq"]=True`) to depend on smoothq_alpha selection >= 0, such that passing smoothq_alpha = -1 now disables smoothquant

### Related issue number

Closes https://github.com/foundation-model-stack/fms-model-optimizer/issues/116

### Was the PR tested

- [X] I have ensured all unit tests pass