### PR TITLE
feat: adjust int8 triton to enable msb/lsb truncation

### DIFF
--- a/fms_mo/custom_ext_kernels/triton_kernels.py
+++ b/fms_mo/custom_ext_kernels/triton_kernels.py
@@ -264,7 +264,8 @@ def imatmul_kernel(
         else:
             accumulator_inner = tl.dot(a, b, accumulator, input_precision="ieee")
 
-        ## ------ MSB truncation by clamp, chunky LSB truncation by rounding/masking --------
+        ## ------ INT MSB truncation is simulated by clamping,
+        #           "special" INT LSB truncation by right and left shift --------
         if max_acc_bits < 32:
             accumulator_inner = tl.maximum(
                 tl.minimum(accumulator_inner, acc_max), acc_min
@@ -530,7 +531,6 @@ def tl_matmul_chunk_truncate(
         c_org_dtype = c.dtype
         c = c.to(acc_dtype)
         assert c.shape[0] == M and c.shape[1] == N, "C shape is inconsistent with A B."
-        # assert acc_dtype == torch.float32, "INT truncation is not yet supported."
 
     # 1D launch kernel where each block gets its own program.
     def grid(META):

--- a/fms_mo/custom_ext_kernels/triton_kernels.py
+++ b/fms_mo/custom_ext_kernels/triton_kernels.py
@@ -101,7 +101,7 @@ def matmul_kernel(
     stride_cm,
     stride_cn,
     chunk_trun_bits,
-    max_acc_bits,
+    max_acc_bits,  # pylint: disable=unused-argument
     truncate_then_accumulate,
     # Meta-parameters
     BLOCK_SIZE_M: tl.constexpr,
@@ -311,7 +311,7 @@ def matmul_kernel_DABC(
     stride_cm,
     stride_cn,
     chunk_trun_bits,
-    max_acc_bits,
+    max_acc_bits,  # pylint: disable=unused-argument
     truncate_then_accumulate,
     # Meta-parameters
     BLOCK_SIZE_M: tl.constexpr,

--- a/fms_mo/custom_ext_kernels/utils.py
+++ b/fms_mo/custom_ext_kernels/utils.py
@@ -700,7 +700,7 @@ def imatmul_ops_reg(
         tar_shape = tuple(m1.shape[:-1]) + (m2.shape[1],)
         m1 = m1.view(re_shape)
 
-        if useINTkernel:
+        if useINTkernel in ["triton", "cutlass"]:
             assert (
                 m1.dtype == torch.int8 and m2.dtype == torch.int8
             ), "When using int matmul, inputs must be 2D and INT8."

--- a/fms_mo/custom_ext_kernels/utils.py
+++ b/fms_mo/custom_ext_kernels/utils.py
@@ -859,6 +859,64 @@ def lower_qmodel_cutlass(
     return mod
 
 
+def lower_qmodel_triton(
+    model: torch.nn.Module,
+    use_dyn_max_act=False,
+    max_acc_bits=32,
+    num_lsb_to_truncate=0,
+    chunk_size=32,
+):
+    """
+    Examplar GPU lowering function using triton. Only swap Qlinears in transformers, nothing else.
+    Triton kernel can be used to:
+    1. test INT8 or FP8 HW performance (kernel is not optimized)
+    2. simulate MSB/LSB truncation effect
+
+    Args:
+        model: nn.Module. should be a fms_mo Qmodel, will do inplace layer swapping, no deepcopy
+        use_dyn_max_act: bool or int, can be False or -1 for per-token, or -2 for perCh. will use
+                        dynamic max quantizer for activation if not False.
+        max_acc_bits: max bits for accumulator, typically FP32 for all FP matmuls and INT32 for all
+                        INT matmuls. But some HW could use fewer bits to trade-off power
+                        efficiency at the expense of higher chance of accumulation "overflow".
+                        For example, an INT24 accumulator can only hold values ranged from -2^23 to
+                        2^23 -1, as opposed to typical range -2^31 to -2^31 -1.
+        num_lsb_to_truncate: number of bits to truncate from LSB side. For example, given fp32 is
+                        s1e8m23, if we choose to truncate 13 mantissa bits from right most side,
+                        i.e. LSB, the resulting number will be s1e8m10, which is TF32.
+        chunk_size: given a matmul of (m, k) @ (k, n), the inner product will be "accumulated" along
+                    k-dim. Since the entire matrix will be partitioned into smaller tiles when being
+                    computed, accumulator will only add a certain num of elements in one shot. This
+                    "chunk size" in k-dim will affect the overflow/underflow of accumulator.
+    """
+    # Third Party
+    from torch.ao.quantization.utils import _parent_name
+
+    # Local
+    from fms_mo.modules.linear import QLinear, QLinearINT8Deploy
+
+    for name, m in model.named_modules():
+        if not isinstance(m, QLinear):
+            continue
+        parent_name, module_name = _parent_name(name)
+        parent_mod = model.get_submodule(parent_name)
+        qmod = getattr(parent_mod, module_name)
+        setattr(
+            parent_mod,
+            module_name,
+            QLinearINT8Deploy.from_fms_mo(
+                qmod,
+                use_int_kernel="triton",
+                use_dynamic_max_act_Qfunc=use_dyn_max_act,
+                max_acc_bits=max_acc_bits,
+                truncate_lsb=num_lsb_to_truncate,
+                chunk_size=chunk_size,
+            ),
+        )
+
+    logger.info(f"\nModel lowering with triton kernel is done.\n{model}")
+
+
 ### -------------------------------------------------------------
 #   GPTQ tensor packing functions for Exllama kernel
 ### -------------------------------------------------------------

--- a/fms_mo/dq.py
+++ b/fms_mo/dq.py
@@ -38,7 +38,7 @@ import torch
 from fms_mo import qconfig_init, qmodel_prep
 from fms_mo.fx.utils import model_size_Wb
 from fms_mo.quant.ptq import (
-    calibration_llm_1GPU,
+    calibration_llm_1GPU_v2,
     dq_llm,
     get_act_scales,
     get_act_scales_1gpu,
@@ -224,9 +224,9 @@ def run_dq(model_args, data_args, opt_args, fms_mo_args):
     if qcfg["qmodel_calibration_new"] > 0:
         logger.info("Starting to calibrate activation clip_val")
         if qcfg["large_model"]:
-            calibration_llm_1GPU(qcfg, model, dq_dataloader)
+            calibration_llm_1GPU_v2(qcfg, model, dq_dataloader)
         else:
-            model.to("cuda:0")
+            model.to("cuda")
             pbar = tqdm(
                 dq_dataloader,
                 desc=" calibration after applying smoothq scale and before inference",

--- a/fms_mo/dq.py
+++ b/fms_mo/dq.py
@@ -172,7 +172,7 @@ def run_dq(model_args, data_args, opt_args, fms_mo_args):
 
     qcfg["seq_len"] = block_size
     qcfg["model"] = model_args.model_name_or_path
-    qcfg["smoothq"] = True
+    qcfg["smoothq"] = fms_mo_args.smoothq_alpha != -1
     qcfg["plotsvg"] = False
 
     calibration_dataset = load_from_disk(data_args.training_data_path)
@@ -217,9 +217,10 @@ def run_dq(model_args, data_args, opt_args, fms_mo_args):
         save_fname="dq",
     )
     logger.info(f"Quantized model {model}")
-    logger.info("Starting to apply smooth scale")
-    dq_llm(model, act_scales, qcfg)
-    logger.info("Finished applying smooth scale")
+    if qcfg["smoothq"]:
+        logger.info("Starting to apply smooth scale")
+        dq_llm(model, act_scales, qcfg)
+        logger.info("Finished applying smooth scale")
     logger.info("==" * 20)
     if qcfg["qmodel_calibration_new"] > 0:
         logger.info("Starting to calibrate activation clip_val")
@@ -249,7 +250,7 @@ def run_dq(model_args, data_args, opt_args, fms_mo_args):
             test_dataset = load_from_disk(data_args.test_data_path)
             test_dataset = test_dataset.with_format("torch")
         elif len(pt_files) > 0:
-            test_dataset = torch.load(pt_files[0])
+            test_dataset = torch.load(pt_files[0], weights_only=False)
 
         logger.info(f"Model for evaluation: {model}")
         if qcfg["large_model"]:
@@ -258,7 +259,8 @@ def run_dq(model_args, data_args, opt_args, fms_mo_args):
             model.to(torch.device("cuda:0"))
             n_samples = int(test_dataset.input_ids.shape[1] / block_size)
             evaluator = Evaluator(test_dataset, "cuda", n_samples=n_samples)
-            ppl = evaluator.evaluate(model, block_size=block_size)
+            with patch_torch_bmm(qcfg):
+                ppl = evaluator.evaluate(model, block_size=block_size)
             logger.info(f"Model perplexity: {ppl}")
         logger.info("-" * 50)
         logger.info("Finished evaluation")

--- a/fms_mo/modules/linear.py
+++ b/fms_mo/modules/linear.py
@@ -742,7 +742,7 @@ class QLinearINT8Deploy(nn.Linear):
             for a_or_w in ["num_bits_feature", "num_bits_weight"]
         ), "Please check nbits setting!"
 
-        target_device = kwargs.get(
+        tar_dev = kwargs.get(
             "target_device",
             kwargs.get("device", next(fms_mo_qlinear.parameters()).device),
         )
@@ -751,7 +751,7 @@ class QLinearINT8Deploy(nn.Linear):
             fms_mo_qlinear.in_features,
             fms_mo_qlinear.out_features,
             bias=fms_mo_qlinear.bias is not None,
-            device=target_device,
+            device=tar_dev,
         )
         # Make sure to register an Op for integer matmul, could be real INT matmul or emulation
         qcfg = getattr(fms_mo_qlinear, "qcfg", {})
@@ -759,6 +759,7 @@ class QLinearINT8Deploy(nn.Linear):
             "use_int_kernel", qcfg.get("use_int_kernel", "cutlass")
         )
         qlin_int.usePTnativeQfunc = kwargs.get("use_PT_native_Qfunc", False)
+        qlin_int.useDynMaxQfunc = kwargs.get("use_dynamic_max_act_Qfunc", False)
         qlin_int.max_acc_bits = kwargs.get("max_acc_bits", 32)
         qlin_int.accminmax = (
             -(1 << (qlin_int.max_acc_bits - 1)),
@@ -773,34 +774,48 @@ class QLinearINT8Deploy(nn.Linear):
         with torch.no_grad():
             Qa = fms_mo_qlinear.quantize_feature
             Qw = fms_mo_qlinear.quantize_weight
-            a_cv, a_cvn = Qa.clip_val.item(), Qa.clip_valn.item()
             w_cv = Qw.clip_val.item()
+            if qlin_int.useDynMaxQfunc in [-1, -2]:  # [-1, -2] indicates reduce_dim
+                # dynamic Qmax has no clipvals, reg fake ones, won't be used in real calc
+                Qa.register_buffer("clip_val", torch.tensor(8.0, device=tar_dev))
+                Qa.register_buffer("clip_valn", torch.tensor(-8.0, device=tar_dev))
+            a_cv, a_cvn = Qa.clip_val.item(), Qa.clip_valn.item()
+            # Store original cv_a and cv_w (in python floats, not tensors), and sq scales
+            # for later use (probably not necessary)
+            qlin_int.cvs = [a_cv, a_cvn, w_cv]
             # NOTE: Keep w transposed to prevent confusion
             Qw.dequantize = False
-            w_int8 = Qw(
-                fms_mo_qlinear.weight.float()
-            )  # Qw.clipval should have been updated after this
+            # trigger Qw.clipval re-calc for SAWB (if needed)
+            w_int8 = Qw(fms_mo_qlinear.weight.float())
             qlin_int.weight = nn.Parameter(
                 w_int8.to(torch.int8), requires_grad=False
             )  # NOTE: may need INT W stored as FP in some cases
 
-            if qlin_int.usePTnativeQfunc:
+            if qlin_int.useDynMaxQfunc in [-1, -2]:
+                input_scale = torch.tensor(1.0, device=tar_dev)
+                input_zero_point = torch.tensor(128, dtype=torch.int, device=tar_dev)
+                w_scale = torch.tensor(
+                    [w_cv * 2 / (2**qlin_int.nbits_w - 2)], device=tar_dev
+                )
+            elif qlin_int.usePTnativeQfunc:
                 input_scale = torch.tensor(
-                    [(a_cv - a_cvn) / (2**qlin_int.nbits_a - 1)], device=target_device
+                    [(a_cv - a_cvn) / (2**qlin_int.nbits_a - 1)], device=tar_dev
                 )
                 input_zero_point = torch.round(-a_cvn / input_scale).to(torch.int)
-                w_scale = torch.tensor([w_cv * 2 / (2**qlin_int.nbits_w - 2)])
+                w_scale = torch.tensor(
+                    [w_cv * 2 / (2**qlin_int.nbits_w - 2)], device=tar_dev
+                )
             else:
                 # fms_mo formula is a bit different from conventional PT formula
                 quant_scale = (2**qlin_int.nbits_a - 1) / torch.tensor(
-                    [a_cv - a_cvn], device=target_device
+                    [a_cv - a_cvn], device=tar_dev
                 )
                 quant_stepsize = 1.0 / quant_scale
                 quant_zero_point = torch.round(a_cvn * quant_scale)
                 input_scale = quant_stepsize
                 input_zero_point = -quant_zero_point
                 quant_w_scale = (2**qlin_int.nbits_a - 2) / torch.tensor(
-                    [w_cv * 2], device=target_device
+                    [w_cv * 2], device=tar_dev
                 )
                 w_scale = 1.0 / quant_w_scale
                 qlin_int.register_buffer("quant_scale", quant_scale)
@@ -812,9 +827,6 @@ class QLinearINT8Deploy(nn.Linear):
             qlin_int.register_buffer("input_zp", input_zero_point)
             qlin_int.register_buffer("w_scale", w_scale)
             qlin_int.register_buffer("w_zp", w_zp)
-            # Store original cv_a and cv_w (in python floats, not tensors), and sq scales
-            # for later verification
-            qlin_int.cvs = [Qa.clip_val.item(), Qa.clip_valn.item(), Qw.clip_val.item()]
 
             corr_term = (
                 (input_zero_point - 128)
@@ -836,17 +848,14 @@ class QLinearINT8Deploy(nn.Linear):
                 qlin_int.register_buffer("bias", -corr_term.to(fms_mo_w_dtype))
                 qlin_int.org_model_has_bias = False
 
-        qlin_int.register_buffer("Qa_clip_val", Qa.clip_val.detach())
-        qlin_int.register_buffer(
-            "Qa_clip_valn", Qa.clip_valn.detach()
-        )  # TODO: case for PACT?
-        qlin_int.register_buffer(
-            "Qw_clip_val", Qw.clip_val.detach()
-        )  # asym W quantizer may have clipvaln
+        # redundant variables to be cleaned up
+        # qlin_int.register_buffer("Qa_clip_val", Qa.clip_val.detach())
+        # qlin_int.register_buffer("Qa_clip_valn", Qa.clip_valn.detach())
+        # qlin_int.register_buffer("Qw_clip_val", Qw.clip_val.detach())
 
         qlin_int.set_matmul_op()
 
-        return qlin_int.to(target_device)
+        return qlin_int.to(tar_dev)
 
     @classmethod
     def from_torch_iW(cls, nnlin_iW, prec, a_cv, a_cvn, w_cv, zero_shift, **kwargs):
@@ -988,25 +997,15 @@ class QLinearINT8Deploy(nn.Linear):
         """
         Quantizes the input tensor x to 8-bit integer values using raw formula, slower if not
         torch.compiled
-
-        Args:
-            x (Tensor): Input tensor to be quantized.
-
-        Returns:
-            Tensor: Quantized tensor with values in the range [-128, 127].
         """
         x = torch.clamp((x / self.input_scale + self.input_zp - 128).round(), -128, 127)
         return x.to(torch.int8)
 
     def qa_fmo_mo_qfunc(self, x):
         """
-        Quantizes the input tensor x to 8-bit integer values.
-
-        Args:
-            x (Tensor): Input tensor to be quantized.
-
-        Returns:
-            Tensor: Quantized tensor with values in the range [-128, 127].
+        Quantizes the input tensor x to 8-bit integer values. Note that old fms-mo formula clamps
+        before rounds, as opposed to typical torch formula that rounds before clamps.
+        (See qa_raw_qfunc() above.)
         """
         x = (
             torch.round(
@@ -1016,6 +1015,21 @@ class QLinearINT8Deploy(nn.Linear):
             - 128
         )
         return x.to(torch.int8)
+
+    def qa_dynamic_max_qfunc(self, x):
+        """
+        Symmetric dynamic quantizer, same as QDynMax, which allows per-token or per-channel.
+        This quantizer will not use self.input_scale but instead will update it every time.
+        NOTE
+        1. self.input_scale.shape should be (x.shape[-2], ) if reduce_dim == -1 and (, x.shape[-1])
+            for reduce_dim == -2.
+        2. input_scale should be be broadcasted correctly together with W_scale (e.g. if per-Ch) at
+            final output step, i.e. imm_out*(a_scale*w_scale)*...
+        """
+        amax = x.abs().max(dim=self.useDynMaxQfunc, keepdim=True)[0]
+        levels = 2 ** (self.nbits_a - 1) - 1
+        self.input_scale = amax.clamp(min=1e-5).div(levels)
+        return torch.round(x / self.input_scale).to(torch.int8)
 
     def iaddmm_int(self, bias, m1, m2):
         """
@@ -1034,7 +1048,9 @@ class QLinearINT8Deploy(nn.Linear):
             The result of the integer matrix multiplication with the bias added.
         """
 
-        if self.usePTnativeQfunc:
+        if self.useDynMaxQfunc in [-1, -2]:
+            m1 = self.qa_dynamic_max_qfunc(m1)
+        elif self.usePTnativeQfunc:
             m1 = self.qa_raw_qfunc(m1)
         else:
             m1 = self.qa_fmo_mo_qfunc(m1)

--- a/fms_mo/prep.py
+++ b/fms_mo/prep.py
@@ -177,7 +177,10 @@ def make_quant_module(module, curr_full_name, qcfg, verbose=False):
     is mappable, create a Qmodule and return, otherwise, return the original module. In the future,
     Qmodules need to have a .from_torch() or .from_nn() classmethod, and then this function will be
     greatly simplified.
-    NOTE: This func will check qskip_layer_name before creating the Qmodule
+    NOTE:
+    1. This func will check qskip_layer_name before creating the Qmodule
+    2. Qmodule will be created on "meta device" as a placeholder, which will skip params init and
+        mem alloc, as weights and bias will be reassigned to module.weight/.bias right after
 
     Args:
         module (nn.Module): the module which Qmodule will be based on
@@ -216,7 +219,7 @@ def make_quant_module(module, curr_full_name, qcfg, verbose=False):
         if hasattr(module, "__constants__"):
             base_params = {k: getattr(module, k) for k in module.__constants__}
             base_params["bias"] = module.bias is not None
-        base_params["device"] = next(module.parameters()).device  # usually cuda
+        base_params["device"] = "meta"
 
     module_output = module
 
@@ -499,8 +502,17 @@ def q_any_net_5(model: nn.Module, qcfg: dict, verbose: bool = False):
     """
     # Third Party
     from torch.ao.quantization.utils import _parent_name
+    from tqdm import tqdm
 
-    for name, module in model.named_modules():
+    total_modules = len(list(model.named_modules()))
+    pbar = tqdm(
+        model.named_modules(),
+        total=total_modules,
+        desc="Mapping modules to target Qmodules.",
+    )
+    for name, module in pbar:
+        pbar.set_description(f"processing {name}")
+
         parent_module_name, curr_mod_name = _parent_name(name)
         new_module = make_quant_module(module, name, qcfg)
         parent_module = model.get_submodule(parent_module_name)
@@ -525,6 +537,7 @@ def q_any_net_5(model: nn.Module, qcfg: dict, verbose: bool = False):
             if verbose:
                 logger.info(f"Swap ({name}) from {type(module)} to {type(new_module)}")
 
+    pbar.close()
     return model
 
 

--- a/fms_mo/quant/quantizers.py
+++ b/fms_mo/quant/quantizers.py
@@ -3183,9 +3183,7 @@ class QmaxPerChSTE(torch.autograd.Function):
     """
 
     @staticmethod
-    def forward(
-        ctx, input_tensor, num_bits, _dequantize, inplace, cv, _cvn, align_zero
-    ):
+    def forward(ctx, input_tensor, num_bits, dequantize, inplace, cv, _cvn, align_zero):
         if inplace:
             ctx.mark_dirty(input_tensor)
         scale = (2**num_bits - 2) if align_zero else (2**num_bits - 1)
@@ -3206,6 +3204,9 @@ class QmaxPerChSTE(torch.autograd.Function):
             quant_min=int_l,
             quant_max=int_u,
         ).to(input_tensor.dtype)
+
+        if not dequantize:
+            return (output.t() / scale).t()
         return output
 
     @staticmethod

--- a/fms_mo/training_args.py
+++ b/fms_mo/training_args.py
@@ -173,6 +173,9 @@ class FMSMOArguments(TypeChecker):
         default=2048, metadata={"help": "input sequence length after tokenization"}
     )
     eval_ppl: bool = field(default=False)
+    aiu_sim_triton: bool = field(
+        default=False, metadata={"help": ("AIU simulation with triton kernel")}
+    )
 
 
 @dataclass


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

MSB/LSB truncation was not completely enabled in triton kernel previously.

### Related issue number

#106 

### How to verify the PR

triton kernel unit test was updated. now MSB truncation case is also included.

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [X] I have ensured all unit tests pass