### PR TITLE
test: Add tests for save_for_aiu functionality w/ tiny models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,8 @@ htmlcov/
 durations/*
 coverage*.xml
 qcfg.json
-models
 configs
+pytest.out
 
 # IDEs
 .vscode/

--- a/fms_mo/quant/quantizers.py
+++ b/fms_mo/quant/quantizers.py
@@ -3029,7 +3029,7 @@ class Qmax(nn.Module):
             self.register_buffer("clip_valn", torch.zeros(perGp[0]))
         else:
             self.register_buffer(
-                "clip_val", torch.zeros(perCh) if perCh else torch.Tensor([1.0])
+                "clip_val", torch.zeros(perCh) if perCh else torch.Tensor([0.0])
             )
             self.register_buffer(
                 "clip_valn", torch.zeros(perCh) if perCh else torch.Tensor([0.0])

--- a/fms_mo/utils/aiu_utils.py
+++ b/fms_mo/utils/aiu_utils.py
@@ -232,6 +232,14 @@ def process_weight(
     is_w_recomputed = False
     if layer_name + ".quantize_weight.clip_val" in model.state_dict():
         w_cv = model.state_dict()[layer_name + ".quantize_weight.clip_val"]
+
+        # Check that clip values are initialized
+        if torch.any(w_cv.isclose(torch.tensor(0.0))):
+            raise ValueError(
+                f"Quantization clip values for {layer_name=} have near-zero values and "
+                "are likely uninitialized."
+            )
+
         if w_cv.numel() > 1:
             w_cv = w_cv.unsqueeze(dim=1)
         weight_int_as_fp = torch.clamp(127 / w_cv * weight_pre_quant, -127, 127).round()

--- a/fms_mo/utils/qconfig_utils.py
+++ b/fms_mo/utils/qconfig_utils.py
@@ -816,8 +816,7 @@ def qconfig_save(
 
     # Save config as json
     if os.path.isfile(fname):
-        message = f"{fname} already exist, will overwrite."
-        warnings.warn(message, UserWarning)
+        logger.info(f"{fname} already exist, will overwrite.")
     with open(fname, "w", encoding="utf-8") as outfile:
         json.dump(temp_qcfg, outfile, indent=4)
 

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -22,6 +22,7 @@ from copy import deepcopy
 import os
 
 # Third Party
+from torch.utils.data import DataLoader, TensorDataset
 from torchvision.io import read_image
 from torchvision.models import ResNet50_Weights, ViT_B_16_Weights, resnet50, vit_b_16
 from transformers import (
@@ -1346,7 +1347,7 @@ def input_tiny() -> DataLoader:
         dataset,
         batch_size=batch_size,
         shuffle=False,
-        collate_fn=lambda batch: tuple(torch.stack(samples) for samples in zip(*batch))
+        collate_fn=lambda batch: tuple(torch.stack(samples) for samples in zip(*batch)),
     )
 
 

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -24,7 +24,15 @@ import os
 # Third Party
 from torchvision.io import read_image
 from torchvision.models import ResNet50_Weights, ViT_B_16_Weights, resnet50, vit_b_16
-from transformers import BertModel, BertTokenizer
+from transformers import (
+    BertConfig,
+    BertModel,
+    BertTokenizer,
+    LlamaConfig,
+    LlamaModel,
+    GraniteConfig,
+    GraniteModel,
+)
 import numpy as np
 import pytest
 import torch
@@ -1299,3 +1307,130 @@ def model_residualMLP():
         torch.nn.Module: _description_
     """
     return ResidualMLP(128)
+
+
+#############################
+# Tiny BERT Model Fixtures #
+#############################
+
+tiny_bert_config_params = [
+    BertConfig(
+        vocab_size=512, # 30522
+        hidden_size=128, # 768
+        num_hidden_layers=2, # 12
+        num_attention_heads=2,# 12
+        intermediate_size=512, # 3072
+        max_position_embeddings=512, # 512
+        type_vocab_size=1, # 2
+    ),
+]
+
+
+@pytest.fixture(scope="session", params=tiny_bert_config_params)
+def config_tiny_bert(request):
+    """
+    Get a tiny Bert config
+
+    Returns:
+        BertConfig: Trimmed Tiny Bert config
+    """
+    return request.param
+
+
+@pytest.fixture(scope="function")
+def model_tiny_bert(config_tiny_bert):
+    """
+    Get a tiny Llama Model based on the config
+
+    Args:
+        config_tiny_bert (BertConfig): Trimmed Tiny Bert config
+
+    Returns:
+        BertConfig: Tiny Bert model
+    """
+    model = deepcopy(BertModel(config_tiny_bert))
+    return model
+
+
+#############################
+# Tiny Llama Model Fixtures #
+#############################
+
+tiny_llama_config_params = [
+    LlamaConfig(
+        vocab_size=1024, # 32000
+        hidden_size=128, # 4096
+        intermediate_size=256, # 11008
+        num_hidden_layers=2, # 32
+        num_attention_heads=2,# 32
+        max_position_embeddings=256, # 2048
+    ),
+]
+
+
+@pytest.fixture(scope="session", params=tiny_llama_config_params)
+def config_tiny_llama(request):
+    """
+    Get a tiny Llama config
+
+    Returns:
+        LlamaConfig: Trimmed Tiny Llama config
+    """
+    return request.param
+
+
+@pytest.fixture(scope="function")
+def model_tiny_llama(config_tiny_llama):
+    """
+    Get a tiny Llama Model based on the config
+
+    Args:
+        config_tiny_llama (LlamaConfig): Trimmed Tiny Llama config
+
+    Returns:
+        LlamaModel: Tiny Llama model
+    """
+    model = deepcopy(LlamaModel(config_tiny_llama))
+    return model
+
+
+###############################
+# Tiny Granite Model Fixtures #
+###############################
+
+tiny_granite_config_params = [
+    GraniteConfig(
+        vocab_size=1024, # 32000
+        hidden_size=128, # 4096
+        intermediate_size=256, # 11008
+        num_hidden_layers=2, # 32
+        num_attention_heads=2,# 32
+        max_position_embeddings=256, # 2048
+    ),
+]
+
+
+@pytest.fixture(scope="session", params=tiny_granite_config_params)
+def config_tiny_granite(request):
+    """
+    Get a tiny Granite config
+
+    Returns:
+        GraniteConfig: Tiny Granite config
+    """
+    return request.param
+
+
+@pytest.fixture(scope="function")
+def model_tiny_granite(config_tiny_granite):
+    """
+    Get a tiny Granite Model based on the config
+
+    Args:
+        config_tiny_granite (GraniteConfig): Trimmed Tiny Granite config
+
+    Returns:
+        GraniteModel: Tiny Granite model
+    """
+    model = deepcopy(GraniteModel(config_tiny_granite))
+    return model

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -38,7 +38,6 @@ import numpy as np
 import pytest
 import torch
 import torch.nn.functional as F
-from torch.utils.data import TensorDataset, DataLoader
 
 # Local
 # fms_mo imports

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -1369,19 +1369,8 @@ tiny_bert_config_params = [
 ]
 
 
-@pytest.fixture(scope="session", params=tiny_bert_config_params)
-def config_tiny_bert(request) -> BertConfig:
-    """
-    Get a tiny Bert config
-
-    Returns:
-        BertConfig: Trimmed Tiny Bert config
-    """
-    return request.param
-
-
-@pytest.fixture(scope="function")
-def model_tiny_bert(config_tiny_bert: BertConfig) -> BertModel:
+@pytest.fixture(scope="function", params=tiny_bert_config_params)
+def model_tiny_bert(request) -> BertModel:
     """
     Get a tiny Llama Model based on the config
 
@@ -1391,7 +1380,7 @@ def model_tiny_bert(config_tiny_bert: BertConfig) -> BertModel:
     Returns:
         BertConfig: Tiny Bert model
     """
-    model = BertModel(config=config_tiny_bert)
+    model = BertModel(config=request.param)
     return model
 
 
@@ -1485,19 +1474,8 @@ tiny_llama_config_params = [
 ]
 
 
-@pytest.fixture(scope="session", params=tiny_llama_config_params)
-def config_tiny_llama(request) -> LlamaConfig:
-    """
-    Get a tiny Llama config
-
-    Returns:
-        LlamaConfig: Trimmed Tiny Llama config
-    """
-    return request.param
-
-
-@pytest.fixture(scope="function")
-def model_tiny_llama(config_tiny_llama: LlamaConfig) -> LlamaModel:
+@pytest.fixture(scope="function", params=tiny_llama_config_params)
+def model_tiny_llama(request) -> LlamaModel:
     """
     Get a tiny Llama Model based on the config
 
@@ -1507,7 +1485,7 @@ def model_tiny_llama(config_tiny_llama: LlamaConfig) -> LlamaModel:
     Returns:
         LlamaModel: Tiny Llama model
     """
-    model = LlamaModel(config=config_tiny_llama)
+    model = LlamaModel(config=request.param)
     return model
 
 
@@ -1585,19 +1563,8 @@ tiny_granite_config_params = [
 ]
 
 
-@pytest.fixture(scope="session", params=tiny_granite_config_params)
-def config_tiny_granite(request) -> GraniteConfig:
-    """
-    Get a tiny Granite config
-
-    Returns:
-        GraniteConfig: Tiny Granite config
-    """
-    return request.param
-
-
-@pytest.fixture(scope="function")
-def model_tiny_granite(config_tiny_granite: GraniteConfig) -> GraniteModel:
+@pytest.fixture(scope="function", params=tiny_granite_config_params)
+def model_tiny_granite(request) -> GraniteModel:
     """
     Get a tiny Granite Model based on the config
 
@@ -1607,7 +1574,7 @@ def model_tiny_granite(config_tiny_granite: GraniteConfig) -> GraniteModel:
     Returns:
         GraniteModel: Tiny Granite model
     """
-    model = GraniteModel(config=config_tiny_granite)
+    model = GraniteModel(config=request.param)
     return model
 
 

--- a/tests/models/test_model_utils.py
+++ b/tests/models/test_model_utils.py
@@ -140,9 +140,9 @@ def qmodule_error(
 ###############################
 
 
-def delete_config(file_path: str = "qcfg.json"):
+def delete_file(file_path: str = "qcfg.json"):
     """
-    Delete a qconfig at the file path provided
+    Delete a file at the file path provided
 
     Args:
         file_path (str, optional): Qconfig file to delete. Defaults to "qcfg.json".
@@ -214,7 +214,7 @@ def load_state_dict(fname: str = "qmodel_for_aiu.pt") -> dict:
     Returns:
         dict: Model state dictionary
     """
-    return torch.load(fname)
+    return torch.load(fname, weights_only=True)
 
 
 def check_linear_dtypes(state_dict: dict, linear_names: list):

--- a/tests/models/test_model_utils.py
+++ b/tests/models/test_model_utils.py
@@ -238,3 +238,4 @@ def check_linear_dtypes(state_dict: dict, linear_names: list):
         for k, v in state_dict.items()
         if all(n not in k for n in linear_names) or not k.endswith(".weight")
     )
+

--- a/tests/models/test_model_utils.py
+++ b/tests/models/test_model_utils.py
@@ -238,4 +238,3 @@ def check_linear_dtypes(state_dict: dict, linear_names: list):
         for k, v in state_dict.items()
         if all(n not in k for n in linear_names) or not k.endswith(".weight")
     )
-

--- a/tests/models/test_qmodelprep.py
+++ b/tests/models/test_qmodelprep.py
@@ -53,6 +53,7 @@ if torch.cuda.is_available():
         with pytest.raises(RuntimeError):
             qmodel_prep(model_quantized, sample_input_fp32, config_fp32)
 
+
 def test_recipe_not_present(
     wrong_recipe_name: str,
 ):

--- a/tests/models/test_save_aiu.py
+++ b/tests/models/test_save_aiu.py
@@ -3,7 +3,7 @@ from transformers import BatchEncoding, BertModel, GraniteModel, LlamaModel
 import pytest
 
 # Local
-from .test_model_utils import check_linear_dtypes, delete_config, load_state_dict
+from .test_model_utils import check_linear_dtypes, delete_file, load_state_dict
 from fms_mo import qmodel_prep
 from fms_mo.utils.aiu_utils import save_for_aiu
 
@@ -13,9 +13,9 @@ def delete_files():
     """
     Delete any known files lingering before starting test
     """
-    delete_config("qcfg.json")
-    delete_config("keys_to_save.json")
-    delete_config("qmodel_for_aiu.pt")
+    delete_file("qcfg.json")
+    delete_file("keys_to_save.json")
+    delete_file("qmodel_for_aiu.pt")
 
 
 def test_save_model_bert(

--- a/tests/models/test_save_aiu.py
+++ b/tests/models/test_save_aiu.py
@@ -85,11 +85,11 @@ def test_large_outlier_bert(
     # Loaded model w/ recomputed SAWB should have widened channel quantization stdev
     for k, v in state_dict.items():
         if k.endswith(".weight") and any(n in k for n in bert_linear_names):
-            perCh_stdev_model = layer2stdev.get(k)
-            perCh_stdev_loaded = v.to(torch.float32).std(dim=stddev_dim)
+            stddev_model = layer2stdev.get(k)
+            stddev_loaded = v.to(torch.float32).std(dim=stddev_dim)
 
             # SAWB stddev should be at least as good as Qmax stddev w/ outlier
-            assert torch.all(perCh_stdev_loaded >= perCh_stdev_model)
+            assert torch.all(stddev_loaded >= stddev_model)
 
 
 def test_clip_vals_zero_bert(

--- a/tests/models/test_save_aiu.py
+++ b/tests/models/test_save_aiu.py
@@ -3,7 +3,11 @@ from transformers import BatchEncoding, BertModel, GraniteModel, LlamaModel
 import pytest
 
 # Local
-from .test_model_utils import check_linear_dtypes, delete_config, load_state_dict
+from .test_model_utils import (
+    check_linear_dtypes,
+    delete_config,
+    load_state_dict,
+)
 from fms_mo import qmodel_prep
 from fms_mo.utils.aiu_utils import save_for_aiu
 
@@ -40,6 +44,50 @@ def test_save_model_bert(
     # Fetch saved state dict
     state_dict = load_state_dict()
     check_linear_dtypes(state_dict, bert_linear_names)
+
+
+def test_large_outlier_bert(
+    model_tiny_bert: BertModel,
+    input_tiny: BatchEncoding,
+    qcfg_bert: dict,
+    bert_linear_names: list,
+):
+    """
+    Test if the recomputation mode increases standard deviation of a tensor with an outlier.
+
+    Args:
+        model_tiny_bert (BertModel): Bert Tiny Model
+        input_tiny (BatchEncoding): Bert Tiny config
+        qcfg_bert (dict): Fake tiny input
+        bert_linear_names (list): Quantized config for Bert
+    """
+    import torch
+
+    # Break every tensor channel with a large magnitude outlier
+    for k,v in model_tiny_bert.state_dict().items():
+        if k.endswith(".weight") and any(n in k for n in bert_linear_names):
+            v[:,0] = 1.21
+
+    # Set recomputation for narrow weights and prep
+    qcfg_bert["recompute_narrow_weights"] = True
+    qmodel_prep(model_tiny_bert, input_tiny, qcfg_bert, use_dynamo=True)
+
+    # Qmax should break the quantization with an outlier to have skinny distribution
+    layer2stdev: dict[str, torch.Tensor] = {}
+    for k,v in model_tiny_bert.state_dict().items():
+        if k.endswith(".weight") and any(n in k for n in bert_linear_names):
+            layer2stdev[k] = v.to(torch.float32).std(dim=-1)
+
+    save_for_aiu(model_tiny_bert, qcfg=qcfg_bert, verbose=True)
+    state_dict = load_state_dict()
+
+    # Loaded model w/ recomputed SAWB should have widened channel quantization stdev
+    for k,v in state_dict.items():
+        if k.endswith(".weight") and any(n in k for n in bert_linear_names):
+            perCh_stdev_model = layer2stdev.get(k)
+            perCh_stdev_loaded = v.to(torch.float32).std(dim=-1)
+           
+            assert torch.all(perCh_stdev_loaded >= perCh_stdev_model)
 
 
 def test_save_model_llama(
@@ -88,3 +136,4 @@ def test_save_model_granite(
     # Fetch saved state dict
     state_dict = load_state_dict()
     check_linear_dtypes(state_dict, granite_linear_names)
+

--- a/tests/models/test_save_aiu.py
+++ b/tests/models/test_save_aiu.py
@@ -1,0 +1,90 @@
+# Third Party
+from transformers import BatchEncoding, BertModel, GraniteModel, LlamaModel
+import pytest
+
+# Local
+from .test_model_utils import check_linear_dtypes, delete_config, load_state_dict
+from fms_mo import qmodel_prep
+from fms_mo.utils.aiu_utils import save_for_aiu
+
+
+@pytest.fixture(autouse=True)
+def delete_files():
+    """
+    Delete any known files lingering before starting test
+    """
+    delete_config("qcfg.json")
+    delete_config("keys_to_save.json")
+    delete_config("qmodel_for_aiu.pt")
+
+
+def test_save_model_bert(
+    model_tiny_bert: BertModel,
+    input_tiny: BatchEncoding,
+    qcfg_bert: dict,
+    bert_linear_names: list,
+):
+    """
+    Save a BERT state dictionary and attempt to reload it to a fresh model
+
+    Args:
+        model_tiny_bert (BertModel): Bert Tiny Model
+        config_tiny_bert (BertConfig): Bert Tiny config
+        input_tiny (BatchEncoding): Fake tiny input
+        qcfg_bert (dict): Quantized config for Bert
+    """
+    # Quantize model and save state dict
+    qmodel_prep(model_tiny_bert, input_tiny, qcfg_bert, use_dynamo=True)
+    save_for_aiu(model_tiny_bert, qcfg=qcfg_bert, verbose=True)
+
+    # Fetch saved state dict
+    state_dict = load_state_dict()
+    check_linear_dtypes(state_dict, bert_linear_names)
+
+
+def test_save_model_llama(
+    model_tiny_llama: LlamaModel,
+    input_tiny: BatchEncoding,
+    qcfg_llama: dict,
+    llama_linear_names: list,
+):
+    """
+    Save a Llama state dictionary and attempt to reload it to a fresh model
+
+    Args:
+        model_tiny_llama (LlamaModel): Llama Tiny Model
+        config_tiny_llama (LlamaConfig): Llama Tiny config
+        input_tiny (BatchEncoding): Fake tiny input
+        qcfg_llama (dict): Quantized config for Llama
+    """
+    # Quantize model and save state dict
+    qmodel_prep(model_tiny_llama, input_tiny, qcfg_llama, use_dynamo=True)
+    save_for_aiu(model_tiny_llama, qcfg=qcfg_llama, verbose=True)
+
+    # Fetch saved state dict
+    state_dict = load_state_dict()
+    check_linear_dtypes(state_dict, llama_linear_names)
+
+
+def test_save_model_granite(
+    model_tiny_granite: GraniteModel,
+    input_tiny: BatchEncoding,
+    qcfg_granite: dict,
+    granite_linear_names: list,
+):
+    """
+    Save a Granite state dictionary and attempt to reload it to a fresh model
+
+    Args:
+        model_tiny_granite (GraniteModel): Granite Tiny Model
+        config_tiny_granite (GraniteConfig): Granite Tiny config
+        input_tiny (BatchEncoding): Fake tiny input
+        qcfg_granite (dict): Quantized config for Granite
+    """
+    # Quantize model and save state dict
+    qmodel_prep(model_tiny_granite, input_tiny, qcfg_granite, use_dynamo=True)
+    save_for_aiu(model_tiny_granite, qcfg=qcfg_granite, verbose=True)
+
+    # Fetch saved state dict
+    state_dict = load_state_dict()
+    check_linear_dtypes(state_dict, granite_linear_names)

--- a/tests/models/test_saveconfig.py
+++ b/tests/models/test_saveconfig.py
@@ -84,6 +84,7 @@ def test_save_config_wanted_pairs(
 
     delete_config()
 
+
 def test_save_config_with_qcfg_save(
     config_fp32: dict,
     save_list: list,
@@ -115,6 +116,7 @@ def test_save_config_with_qcfg_save(
 
     delete_config()
     del config_fp32["keys_to_save"]
+
 
 def test_save_config_with_recipe_save(
     config_fp32: dict,
@@ -153,6 +155,7 @@ def test_save_config_with_recipe_save(
 
     delete_config()
     delete_config("keys_to_save.json")
+
 
 def test_save_config_minimal(
     config_fp32: dict,
@@ -197,6 +200,7 @@ def test_double_qconfig_save(
         qconfig_save(config_fp32, minimal=False)
 
     delete_config()
+
 
 def test_qconfig_save_list_as_dict(
     config_fp32: dict,
@@ -247,7 +251,6 @@ def test_qconfig_save_recipe_as_dict(
     }
     save_json(save_dict, file_path="keys_to_save.json")
 
-
     with pytest.raises(ValueError):
         qconfig_save(config_fp32, recipe="keys_to_save.json", minimal=True)
 
@@ -265,7 +268,7 @@ def test_qconfig_load_with_recipe_as_list(
     """
     delete_config()
 
-    config_list = list( config_fp32.keys() )
+    config_list = list(config_fp32.keys())
 
     save_json(config_list, file_path="qcfg.json")
 

--- a/tests/models/test_toymodels.py
+++ b/tests/models/test_toymodels.py
@@ -20,6 +20,7 @@ Test functionality of quantization workflow on toy models
 from copy import deepcopy
 
 # Third Party
+import pytest
 import torch
 
 # Local
@@ -27,11 +28,19 @@ from fms_mo import qmodel_prep
 from fms_mo.modules.conv import DetQConv2d, QConv2d, QConv2dPTQ, QConv2dPTQv2
 from fms_mo.modules.linear import QLinear
 from tests.models.test_model_utils import (
-    delete_config,
+    delete_file,
     is_qconv2d,
     is_qlinear,
     is_quantized_layer,
 )
+
+
+@pytest.fixture(autouse=True)
+def delete_files():
+    """
+    Delete any known files lingering before starting test
+    """
+    delete_file("qcfg.json")
 
 
 def test_subclass():
@@ -65,8 +74,6 @@ def test_first_layer_unchanged_fp32(
         sample_input_fp32 (torch.FloatTensor): Sample fp32 input for calibration.
         config_fp32 (dict): Config w/ fp32 settings
     """
-    delete_config()
-
     # Grab copy of first layer before quantization
     first_layer = deepcopy(model_fp32.first_layer)
 
@@ -107,8 +114,6 @@ def test_first_layer_unchanged_fp16(
         sample_input_fp16 (torch.FloatTensor): Sample fp16 input for calibration.
         config_fp16 (dict): Config w/ fp16 settings
     """
-    delete_config()
-
     # Grab copy of first layer before quantization
     first_layer = deepcopy(model_fp16.first_layer)
 
@@ -152,8 +157,6 @@ def test_second_layer_quantized_fp32(
         sample_input_fp32 (torch.FloatTensor): Sample fp32 input for calibration.
         config_fp32 (dict): Config w/ fp32 settings
     """
-    delete_config()
-
     if hasattr(model_fp32, "second_layer"):
         # Copy 2nd layer before quantization
         second_layer = deepcopy(model_fp32.second_layer)
@@ -215,8 +218,6 @@ def test_second_layer_quantized_fp16(
         sample_input_fp16 (torch.FloatTensor): Sample fp16 input for calibration.
         config_fp16 (dict): Config w/ fp16 settings
     """
-    delete_config()
-
     if hasattr(model_fp16, "second_layer"):
         # Copy 2nd layer before quantization
         second_layer = deepcopy(model_fp16.second_layer)
@@ -273,8 +274,6 @@ def test_qmodel_prep_output_fp32(
         sample_input_fp32 (torch.FloatTensor): Sample fp32 input for calibration.
         config_fp32 (dict): Config w/ fp32 settings
     """
-    delete_config()
-
     # need to detach to make deepcopy
     original_output = deepcopy(model_fp32(sample_input_fp32).detach())
 
@@ -300,8 +299,6 @@ def test_qmodel_prep_output_fp16(
         sample_input_fp16 (torch.FloatTensor): Sample fp16 input for calibration.
         config_fp16 (dict): Config w/ fp16 settings
     """
-    delete_config()
-
     # need to detach to make deepcopy
     original_output = deepcopy(model_fp16(sample_input_fp16).detach())
     qmodel_prep(model_fp16, sample_input_fp16, config_fp16)
@@ -329,8 +326,6 @@ def test_qmodel_prep_num_bits_output_fp32(
         num_bits_weight_fp32 (int): nbits_w valid for fp32
         config_fp32 (dict): Config w/ fp32 settings
     """
-    delete_config()
-
     # Get model output before quantization
     original_output = deepcopy(model_fp32(sample_input_fp32).detach())
 
@@ -397,8 +392,6 @@ def test_qmodel_prep_num_bits_output_fp16(
         num_bits_weight_fp16 (int): nbits_w valid for fp16
         config_fp16 (dict): Config w/ fp16 settings
     """
-    delete_config()
-
     # Get model output before quantization
     original_output = deepcopy(model_fp16(sample_input_fp16).detach())
 


### PR DESCRIPTION
### Description of the change

Added a new tests/models named test_save_aiu.py.  This includes implementing new "tiny" models for BERT, Llama, and Granite from custom configs that are trimmed down.

Also, several test files have been cleaned up with the new autouse=True fixture for file deletion before a test starts.

### How to verify the PR

Change to tests/models and run `pytest test_save_aiu.py`

### Was the PR tested

<!-- Describe how PR was tested -->
- [x] I have ensured all unit tests pass