### PR TITLE
fix: disable granite in custom gptq as gptqmodel already supports it, fix …

### DIFF
--- a/fms_mo/run_quant.py
+++ b/fms_mo/run_quant.py
@@ -144,6 +144,12 @@ def run_gptq(model_args, data_args, opt_args, gptq_args):
 
     # Add custom model_type mapping to gptqmodel LUT so GPTQModel can recognize them.
     for mtype, cls in custom_gptq_classes.items():
+        if mtype in MODEL_MAP:
+            logger.info(
+                f"Custom GPTQ model type {mtype} already exists in default MODEL_MAP.\n"
+                "The mapping for this type is overwritten by user defined type now."
+                "Please make sure this is the behavior you'd like to have."
+            )
         SUPPORTED_MODELS.append(mtype)
         MODEL_MAP[mtype] = cls
 

--- a/fms_mo/utils/custom_gptq_models.py
+++ b/fms_mo/utils/custom_gptq_models.py
@@ -49,6 +49,6 @@ class GraniteMoeGPTQForCausalLM(BaseGPTQModel):
 #       config.json). Make sure you cover the ones in the model family you want to use, as they may
 #       not be under the same model_type. See Granite as an example.
 custom_gptq_classes = {
-    "granite": GraniteGPTQForCausalLM,
+    # "granite": GraniteGPTQForCausalLM,
     "granitemoe": GraniteMoeGPTQForCausalLM,
 }


### PR DESCRIPTION
…for PR102

<!-- Thank you for the contribution! -->

### Description of the change

minor fix for previously merged PR 102, just disable `granite` in custom gptq model as `gptqmodel` package has native support already.

### Related issues or PRs

#102 

### (Optional) List any documentation or testing added


### (Optional) How to verify the contribution


### Checklist for passing CI/CD:

<!-- Mark completed tasks with "- [x]" -->
- [X] All commits are signed showing "Signed-off-by: Name \<email@domain.com\>" with `git commit -signoff` or equivalent
- [X] PR title and commit messages adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Contribution is formatted with `tox -e fix`
- [ ] Contribution passes linting with `tox -e lint`
- [ ] Contribution passes spellcheck with `tox -e spellcheck`
- [ ] Contribution passes all unit tests with `tox -e unit`

Note: CI/CD performs unit tests on multiple versions of Python from a fresh install.  There may be differences with your local environment and the test environment.