### PR TITLE
fix: fix typo in GPTQ README.md

### DIFF
--- a/examples/GPTQ/README.md
+++ b/examples/GPTQ/README.md
@@ -72,7 +72,7 @@ This end-to-end example utilizes the common set of interfaces provided by `fms_m
 
     ```bash
     lm_eval --model hf \
-            --model_args pretrained="Meta-Llama-3-8B-GPTQ,dtype=float16,gptqmodel=True=True,enforce_eager=True" \
+            --model_args pretrained="Meta-Llama-3-8B-GPTQ,dtype=float16,gptqmodel=True,enforce_eager=True" \
             --tasks lambada_openai \
             --num_fewshot 5 \
             --device cuda:0 \


### PR DESCRIPTION
### Description of the change

typo again, duplicated `=True`

### Checklist for passing CI/CD:

<!-- Mark completed tasks with "- [x]" -->
- [X] All commits are signed showing "Signed-off-by: Name \<email@domain.com\>" with `git commit -signoff` or equivalent
- [X] PR title and commit messages adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Contribution is formatted with `tox -e fix`
- [ ] Contribution passes linting with `tox -e lint`
- [ ] Contribution passes spellcheck with `tox -e spellcheck`
- [ ] Contribution passes all unit tests with `tox -e unit`

Note: CI/CD performs unit tests on multiple versions of Python from a fresh install.  There may be differences with your local environment and the test environment.