### PR TITLE
feat: Add QmaxDynamic to allow unify Qmax , Qminmax, pertokenmax

### DIFF
--- a/fms_mo/quant/quantizers.py
+++ b/fms_mo/quant/quantizers.py
@@ -145,13 +145,6 @@ def get_activation_quantizer(
             act_quantizer = QFixSymmetric(
                 nbits, init_clip_val=clip_val, align_zero=align_zero
             )
-        elif qa_mode == "maxsym":
-            act_quantizer = Qmax(
-                nbits,
-                align_zero=True,
-                minmax=False,
-                extend_act_range=extend_act_range,
-            )
         elif qa_mode == "pactsym":
             act_quantizer = PACT2Sym(
                 nbits,


### PR DESCRIPTION
<!-- Thank you for the contribution! -->



<!-- Please summarize the changes -->

This adds new quantizer namely QmaxDynamic which includes all functionality providing  a dynamic version of  Qmax, Qminmax and pertokenmax. Additionally, it allows perCh or pertoken quantization features.

### Related issues or PRs
None
<!-- For example: "Closes #1234" or "Fixes bug introduced in #5678 -->

### How to verify the PR
All previous tests build for Qmax, Qminmax and pertokenmax should invoke this new quantizer.


<!-- Please provide instruction or screenshots on how to verify the PR if unit tests do not provide coverage.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added (if that coverage is difficult, please briefly explain the reason)
- [ ] I have ensured all unit tests pass

### Checklist for passing CI/CD:

<!-- Mark completed tasks with "- [x]" -->
- [x] All commits are signed showing "Signed-off-by: Name \<email@domain.com\>" with `git commit -signoff` or equivalent
- [x] PR title and commit messages adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Contribution is formatted with `tox -e fix`
- [x] Contribution passes linting with `tox -e lint`
- [x] Contribution passes spellcheck with `tox -e spellcheck`
- [x] Contribution passes all unit tests with `tox -e unit`

Note: CI/CD performs unit tests on multiple versions of Python from a fresh install.  There may be differences with your local environment and the test environment.