### PR TITLE
build: Move triton to an optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ The following optional dependencies are available:
 - `mx`: `microxcaling` package for MX quantization
 - `opt`: Shortcut for `fp8`, `gptq`, and `mx` installs
 - `torchvision`: `torch` package for image recognition training and inference
+- `triton`: `triton` package for matrix multiplication kernels
 - `visualize`: Dependencies for visualizing models and performance data
 - `test`: Dependencies needed for unit testing
 - `dev`: Dependencies needed for development

--- a/fms_mo/custom_ext_kernels/triton_kernels.py
+++ b/fms_mo/custom_ext_kernels/triton_kernels.py
@@ -17,7 +17,7 @@
 # Third Party
 import torch
 
-# First Party
+# Local
 from fms_mo.utils.import_utils import available_packages
 
 # Assume any calls to the file are requesting triton
@@ -27,10 +27,10 @@ if not available_packages["triton"]:
     )
 
 # Third Party
+# pylint: disable=wrong-import-position
 from triton.language.extra import libdevice
 import triton
 import triton.language as tl
-
 
 DTYPE_I8 = [torch.int8]
 DTYPE_F8 = [torch.float8_e4m3fn, torch.float8_e5m2]

--- a/fms_mo/custom_ext_kernels/triton_kernels.py
+++ b/fms_mo/custom_ext_kernels/triton_kernels.py
@@ -15,10 +15,22 @@
 """This file contains external kernels for FP and INT8 matmul written in triton."""
 
 # Third Party
-from triton.language.extra import libdevice
 import torch
+
+# First Party
+from fms_mo.utils.import_utils import available_packages
+
+# Assume any calls to the file are requesting triton
+if not available_packages["triton"]:
+    raise ImportError(
+        "triton python package is not avaialble, please check your installation."
+    )
+
+# Third Party
+from triton.language.extra import libdevice
 import triton
 import triton.language as tl
+
 
 DTYPE_I8 = [torch.int8]
 DTYPE_F8 = [torch.float8_e4m3fn, torch.float8_e5m2]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
 "accelerate>=0.20.3,!=0.34,<1.7",
 "transformers>=4.45,<4.52",
 "torch>=2.2.0,<2.6", 
-"triton>=3.0,<3.4",
 "tqdm>=4.66.2,<5.0",
 "datasets>=3.0.0,<4.0",
 "ninja>=1.11.1.1,<2.0",
@@ -47,6 +46,7 @@ mx = ["microxcaling>=1.1"]
 opt = ["fms-model-optimizer[fp8, gptq, mx]"]
 torchvision = ["torchvision>=0.17"]
 flash-attn = ["flash-attn>=2.5.3,<3.0"]
+triton = ["triton>=3.0,<3.4"]
 visualize = ["matplotlib", "graphviz", "pygraphviz"]
 dev = ["pre-commit>=3.0.4,<5.0"]
 test = ["pytest", "pillow"]

--- a/tests/triton_kernels/test_triton_mm.py
+++ b/tests/triton_kernels/test_triton_mm.py
@@ -32,7 +32,7 @@ else:
     )
 
 
-@pytest.mark.parametrize("mkn", [64, 256, 1024, 4096])
+@pytest.mark.parametrize("mkn", [64, 256, 1024])
 @pytest.mark.parametrize(
     "dtype_to_test",
     [
@@ -43,11 +43,12 @@ else:
         torch.float8_e5m2,
     ],
 )
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="test_triton_matmul_fp can only when GPU is available",
+)
 def test_triton_matmul_fp(mkn, dtype_to_test):
     """Parametric tests for triton matmul kernel using variety of tensor sizes and dtypes."""
-    if not torch.cuda.is_available():
-        # only run the test when GPU is available
-        return
 
     torch.manual_seed(23)
     m = n = k = mkn
@@ -79,12 +80,13 @@ def test_triton_matmul_fp(mkn, dtype_to_test):
     assert torch.norm(diff_trun_8b) / torch.norm(torch_output) < 1e-3
 
 
-@pytest.mark.parametrize("mkn", [64, 256, 1024, 4096])
+@pytest.mark.parametrize("mkn", [64, 256, 1024])
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="test_triton_matmul_int8 can only when GPU is available",
+)
 def test_triton_matmul_int8(mkn):
     """Parametric tests for triton imatmul kernel using variety of tensor sizes."""
-    if not torch.cuda.is_available():
-        # only run the test when GPU is available
-        return
 
     torch.manual_seed(23)
     m = n = k = mkn
@@ -121,13 +123,14 @@ def test_triton_matmul_int8(mkn):
 
 @pytest.mark.parametrize("feat_in_out", [(64, 128), (256, 1024), (1024, 4096)])
 @pytest.mark.parametrize("trun_bits", [0, 8, 12, 16])
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="test_linear_fpx_acc can only when GPU is available",
+)
 def test_linear_fpx_acc(feat_in_out, trun_bits):
     """Parametric tests for LinearFPxAcc. This Linear utilizes triton kernel hence can only be run
     on CUDA.
     """
-    if not torch.cuda.is_available():
-        # only run the test when GPU is available
-        return
 
     torch.manual_seed(23)
     feat_in, feat_out = feat_in_out


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

This change moves triton to being an optional package.  An additional guard was added, along with minor changes to the test script.

### Related issues or PRs

N/A

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR if unit tests do not provide coverage.-->

### Was the PR tested

Triton tests are now skipped on CI/CD rather than passing via a quick return.

```
tests/triton_kernels/test_triton_mm.py ssssssssssssssssssssssssssssss
```

Locally, on my machine I am getting 9x failures from one of the tests:

```
FAILED tests/triton_kernels/test_triton_mm.py::test_triton_matmul_fp[dtype_to_test4-1024] - AssertionError: assert (tensor(1725.2465, device='cuda:0') / tensor(32604.6211, device='cuda:0')) < 1e-05
```

### Checklist for passing CI/CD:

<!-- Mark completed tasks with "- [x]" -->
- [x] All commits are signed showing "Signed-off-by: Name \<email@domain.com\>" with `git commit -signoff` or equivalent
- [x] PR title and commit messages adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Contribution is formatted with `tox -e fix`
- [x] Contribution passes linting with `tox -e lint`
- [x] Contribution passes spellcheck with `tox -e spellcheck`
- [ ] Contribution passes all unit tests with `tox -e unit`

Note: CI/CD performs unit tests on multiple versions of Python from a fresh install.  There may be differences with your local environment and the test environment.