### PR TITLE
feat: add QA and MaskedLM task for FP8 encoder instantiation

### DIFF
--- a/fms_mo/run_quant.py
+++ b/fms_mo/run_quant.py
@@ -36,7 +36,11 @@ import traceback
 from datasets import load_from_disk
 from huggingface_hub.errors import HFValidationError
 from torch.cuda import OutOfMemoryError
-from transformers import AutoTokenizer
+from transformers import (
+    AutoModelForMaskedLM,
+    AutoModelForQuestionAnswering,
+    AutoTokenizer,
+)
 import torch
 import transformers
 
@@ -204,9 +208,23 @@ def run_fp8(model_args, data_args, opt_args, fp8_args):
 
     logger = set_log_level(opt_args.log_level, "fms_mo.run_fp8")
 
-    model = SparseAutoModelForCausalLM.from_pretrained(
-        model_args.model_name_or_path, torch_dtype=model_args.torch_dtype
-    )
+    if model_args.task_type == "lm":
+        model = SparseAutoModelForCausalLM.from_pretrained(
+            model_args.model_name_or_path,
+            torch_dtype=model_args.torch_dtype,
+        )
+    elif model_args.task_type == "qa":
+        model = AutoModelForQuestionAnswering.from_pretrained(
+            model_args.model_name_or_path,
+            torch_dtype=model_args.torch_dtype,
+        )
+    elif model_args.task_type == "mlm":
+        model = AutoModelForMaskedLM.from_pretrained(
+            model_args.model_name_or_path,
+            torch_dtype=model_args.torch_dtype,
+        )
+    else:
+        raise ValueError(f"Unsupported task: {model_args.task_type}")
     tokenizer = AutoTokenizer.from_pretrained(model_args.model_name_or_path)
 
     recipe = QuantizationModifier(

--- a/fms_mo/training_args.py
+++ b/fms_mo/training_args.py
@@ -55,6 +55,17 @@ class ModelArguments(TypeChecker):
     """Dataclass for model related arguments."""
 
     model_name_or_path: str = field(default="facebook/opt-125m")
+    task_type: str = field(
+        default="lm",
+        metadata={
+            "choices": ["lm", "qa", "mlm"],
+            "help": (
+                "Instantiate model for selected task: 'lm' (language modeling), 'qa' "
+                "(question answering, for encoders), 'mlm' (masked language modeling, "
+                "for encoders)."
+            ),
+        },
+    )
     torch_dtype: str = field(default="bfloat16")
     device_map: Optional[str] = field(
         default=None,


### PR DESCRIPTION
### Description of the change

Add option to instantiate a `QuestionAnswering` or a `MaskedLM` architecture for FP8 quantization via the llm_compressor path.
This option is needed for FP8 quantization of encoder-only models. Architecture selection is done via a new `task_type` keyword, which is being added to the ModelArguments class. Its default is `lm` (language modeling, for decoders). New options: `qa` (QuestionAnswering) and `mlm` (MaskedLM). This argument is only used as part of the FP8 llm_compressor path.

### Related issues or PRs

n/a

### How to verify the PR

Modify DQ example launch script as follows:
```
python -m fms_mo.run_quant \
    --model_name_or_path path/to/non/quantized/encoder/model \
    --quant_method fp8 \
    --task_type qa \
    --ignore qa_outputs \
    --torch_dtype float16 \
    --output_dir path/to/output \
```

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added (if that coverage is difficult, please briefly explain the reason)
- [X] I have ensured all unit tests pass

### Checklist for passing CI/CD:

<!-- Mark completed tasks with "- [x]" -->
- [X] All commits are signed showing "Signed-off-by: Name \<email@domain.com\>" with `git commit -signoff` or equivalent
- [X] PR title and commit messages adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Contribution is formatted with `tox -e fix`
- [X] Contribution passes linting with `tox -e lint`
- [X] Contribution passes spellcheck with `tox -e spellcheck`
- [X] Contribution passes all unit tests with `tox -e unit`

Note: CI/CD performs unit tests on multiple versions of Python from a fresh install.  There may be differences with your local environment and the test environment.