### PR TITLE
fix available_packages

### DIFF
--- a/fms_mo/utils/import_utils.py
+++ b/fms_mo/utils/import_utils.py
@@ -16,9 +16,17 @@
 Utils for storing what optional dependencies are available
 """
 
+# Standard
+import pkgutil
+import sys
+
 # Third Party
 from transformers.utils.import_utils import _is_package_available
 import torch
+
+all_available_modules = []
+for finder, name, ispkg in pkgutil.iter_modules(sys.path):
+    all_available_modules.append(name)
 
 optional_packages = [
     "gptqmodel",
@@ -37,7 +45,9 @@ optional_packages = [
 
 available_packages = {}
 for package in optional_packages:
-    available_packages[package] = _is_package_available(package)
+    available_packages[package] = (
+        _is_package_available(package) or package in all_available_modules
+    )
 
 # cutlass is detected through torch.ops.cutlass_gemm
 available_packages["cutlass"] = hasattr(torch.ops, "cutlass_gemm") and hasattr(


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

`available_packages` dict in `fms_mo.utils.import_utils` had some issue detecting `fms` even though it's installed and functioning.

### Related issues or PRs

minor bug, reported by Alberto through Slack directly.

### How to verify the PR

this is a test on a certain linux machine that has `fms` installed but not `mx`
```python
<on a certain linux machine>:~/projects/fms-mo-fork$ python
Python 3.12.11 | packaged by conda-forge | (main, Jun  4 2025, 14:45:31) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from fms_mo.utils.import_utils import available_packages
GPTQModel is not properly installed. QLinearExv1WI4AF16 and QLinearExv2WI4AF16 wrappers will not be available.
>>> available_packages["mx"]
False
>>> available_packages["fms"]
True
>>> exit()
```

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added (if that coverage is difficult, please briefly explain the reason)
- [X] I have ensured all unit tests pass

### Checklist for passing CI/CD:

<!-- Mark completed tasks with "- [x]" -->
- [X] All commits are signed showing "Signed-off-by: Name \<email@domain.com\>" with `git commit -signoff` or equivalent
- [X] PR title and commit messages adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Contribution is formatted with `tox -e fix`
- [X] Contribution passes linting with `tox -e lint`
- [X] Contribution passes spellcheck with `tox -e spellcheck`
- [X] Contribution passes all unit tests with `tox -e unit`

Note: CI/CD performs unit tests on multiple versions of Python from a fresh install.  There may be differences with your local environment and the test environment.