### PR TITLE
fix: Remove gptqmodel Warning on startup

### DIFF
--- a/fms_mo/custom_ext_kernels/utils.py
+++ b/fms_mo/custom_ext_kernels/utils.py
@@ -517,8 +517,8 @@ def exllama_ops_load_and_reg(qcfg=None, run_unit_test=False):
         need_registration = False
     else:
         need_registration = (
-            available_packages["exllama_kernels"]
-            and available_packages["exllamav2_kernels"]
+            available_packages["gptqmodel_exllama_kernels"]
+            and available_packages["gptqmodel_exllamav2_kernels"]
         )
 
         if not need_registration:

--- a/fms_mo/modules/linear.py
+++ b/fms_mo/modules/linear.py
@@ -1583,7 +1583,13 @@ class QLinearCutlassI8I32NT(QLinearCublasI8I32NT):
         return x.to(in_dtype)
 
 
-try:
+gptq_available = (
+    available_packages["gptqmodel"]
+    and available_packages["gptqmodel_exllama_kernels"]
+    and available_packages["gptqmodel_exllamav2_kernels"]
+)
+
+if gptq_available:
     # Third Party
     from gptqmodel.nn_modules.qlinear.exllama import (
         ExllamaQuantLinear as QLinearExllamaV1,
@@ -1881,12 +1887,6 @@ try:
                 if self.bias is not None:
                     x.add_(self.bias)
                 return x
-
-except ModuleNotFoundError:
-    logger.warning(
-        "GPTQModel is not properly installed. "
-        "QLinearExv1WI4AF16 and QLinearExv2WI4AF16 wrappers will not be available."
-    )
 
 
 class LinearFuncFPxFwdBwd(torch.autograd.Function):
@@ -2354,6 +2354,14 @@ QLinear_modules = (
 )
 if available_packages["mx"]:
     QLinear_modules += (QLinearMX,)
+
+if gptq_available:
+    QLinear_modules += (
+        QLinearExllamaV1,
+        QLinearExllamaV2,
+        QLinearExv1WI4AF16,
+        QLinearExv2WI4AF16,
+    )
 
 
 def isinstance_qlinear(module):

--- a/fms_mo/utils/custom_gptq_models.py
+++ b/fms_mo/utils/custom_gptq_models.py
@@ -14,41 +14,42 @@
 
 """Allow users to add new GPTQ classes for their custom models easily."""
 
-# Third Party
-from gptqmodel.models.base import BaseGPTQModel
+# Local
+from fms_mo.utils.import_utils import available_packages
 
+if available_packages["gptqmodel"]:
+    # Third Party
+    from gptqmodel.models.base import BaseGPTQModel
 
-class GraniteGPTQForCausalLM(BaseGPTQModel):
-    """Enable Granite for GPTQ."""
+    class GraniteGPTQForCausalLM(BaseGPTQModel):
+        """Enable Granite for GPTQ."""
 
-    layer_type = "GraniteDecoderLayer"
-    layers_node = "model.layers"
-    base_modules = ["model.embed_tokens", "model.norm"]
-    layer_modules = [
-        ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],
-        ["self_attn.o_proj"],
-        ["mlp.up_proj", "mlp.gate_proj"],
-        ["mlp.down_proj"],
-    ]
+        layer_type = "GraniteDecoderLayer"
+        layers_node = "model.layers"
+        base_modules = ["model.embed_tokens", "model.norm"]
+        layer_modules = [
+            ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],
+            ["self_attn.o_proj"],
+            ["mlp.up_proj", "mlp.gate_proj"],
+            ["mlp.down_proj"],
+        ]
 
+    class GraniteMoeGPTQForCausalLM(BaseGPTQModel):
+        """Enable Granite MOE for GPTQ."""
 
-class GraniteMoeGPTQForCausalLM(BaseGPTQModel):
-    """Enable Granite MOE for GPTQ."""
+        layer_type = "GraniteMoeDecoderLayer"
+        layers_node = "model.layers"
+        base_modules = ["model.embed_tokens", "model.norm"]
+        layer_modules = [
+            ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],
+            ["self_attn.o_proj"],
+            ["block_sparse_moe.input_linear", "block_sparse_moe.output_linear"],
+        ]
 
-    layer_type = "GraniteMoeDecoderLayer"
-    layers_node = "model.layers"
-    base_modules = ["model.embed_tokens", "model.norm"]
-    layer_modules = [
-        ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],
-        ["self_attn.o_proj"],
-        ["block_sparse_moe.input_linear", "block_sparse_moe.output_linear"],
-    ]
-
-
-# NOTE: Keys in this table are huggingface config."model_type" (see the corresponding field in
-#       config.json). Make sure you cover the ones in the model family you want to use, as they may
-#       not be under the same model_type. See Granite as an example.
-custom_gptq_classes = {
-    # "granite": GraniteGPTQForCausalLM,
-    "granitemoe": GraniteMoeGPTQForCausalLM,
-}
+    # NOTE: Keys in this table are huggingface config."model_type" (see the corresponding field in
+    #       config.json). Make sure you cover the ones in the model family you want to use,
+    #       as they may not be under the same model_type. See Granite as an example.
+    custom_gptq_classes = {
+        # "granite": GraniteGPTQForCausalLM,
+        "granitemoe": GraniteMoeGPTQForCausalLM,
+    }


### PR DESCRIPTION
### Description of the change

This change removes the warning for gptqmodel, as well as adds additional safeguards for the optional dependency.
Also, this fixes a minor bug with the available_package check in modules/linear.py, as it was checking for the auto_gptq external kernels instead of gptqmodel's version.

### Related issues or PRs

Closes #99

### How to verify the PR

On main:
```shell
python3
>>> import fms_mo
GPTQModel is not properly installed. QLinearExv1WI4AF16 and QLinearExv2WI4AF16 wrappers will not be available.
>>> 
```

This PR:
```shell
python3
>>> import fms_mo
>>> 
```

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added (if that coverage is difficult, please briefly explain the reason)
- [x] I have ensured all unit tests pass

### Checklist for passing CI/CD:

<!-- Mark completed tasks with "- [x]" -->
- [x] All commits are signed showing "Signed-off-by: Name \<email@domain.com\>" with `git commit -signoff` or equivalent
- [x] PR title and commit messages adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Contribution is formatted with `tox -e fix`
- [x] Contribution passes linting with `tox -e lint`
- [x] Contribution passes spellcheck with `tox -e spellcheck`
- [x] Contribution passes all unit tests with `tox -e unit`

Note: CI/CD performs unit tests on multiple versions of Python from a fresh install.  There may be differences with your local environment and the test environment.