### PR TITLE
fix: Remove llmcompressor oneshot import deprecation warning

### DIFF
--- a/examples/FP8_QUANT/README.md
+++ b/examples/FP8_QUANT/README.md
@@ -92,7 +92,8 @@ This end-to-end example utilizes the common set of interfaces provided by `fms_m
 
     ```python
     from llmcompressor.modifiers.quantization import QuantizationModifier
-    from llmcompressor.transformers import SparseAutoModelForCausalLM, oneshot
+    from llmcompressor.transformers import SparseAutoModelForCausalLM
+    from llmcompressor import oneshot
 
     model = SparseAutoModelForCausalLM.from_pretrained(model_args.model_name_or_path, torch_dtype=model_args.torch_dtype)
     tokenizer = AutoTokenizer.from_pretrained(model_args.model_name_or_path)

--- a/fms_mo/run_quant.py
+++ b/fms_mo/run_quant.py
@@ -198,8 +198,9 @@ def run_fp8(model_args, data_args, opt_args, fp8_args):
     """
 
     # Third Party
+    from llmcompressor import oneshot
     from llmcompressor.modifiers.quantization import QuantizationModifier
-    from llmcompressor.transformers import SparseAutoModelForCausalLM, oneshot
+    from llmcompressor.transformers import SparseAutoModelForCausalLM
 
     logger = set_log_level(opt_args.log_level, "fms_mo.run_fp8")
 


### PR DESCRIPTION
### Description of the change

This PR fixes a warning issued by llmcompressor for a deprecated import.

### Related issues or PRs

Closes #145

### How to verify the PR

Run fp8 example.  No deprecated import warning should appear.

### Checklist for passing CI/CD:

<!-- Mark completed tasks with "- [x]" -->
- [x] All commits are signed showing "Signed-off-by: Name \<email@domain.com\>" with `git commit -signoff` or equivalent
- [x] PR title and commit messages adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Contribution is formatted with `tox -e fix`
- [x] Contribution passes linting with `tox -e lint`
- [x] Contribution passes spellcheck with `tox -e spellcheck`
- [x] Contribution passes all unit tests with `tox -e unit`

Note: CI/CD performs unit tests on multiple versions of Python from a fresh install.  There may be differences with your local environment and the test environment.