### PR TITLE
feat: AIU sim for FP8 (DL8/DL16) added to triton kernel

### DIFF
--- a/fms_mo/custom_ext_kernels/triton_kernels.py
+++ b/fms_mo/custom_ext_kernels/triton_kernels.py
@@ -184,7 +184,7 @@ def matmul_kernel(
         if chunk_trun_bits > 0:
             accumulator_inner = round_and_trun(accumulator_inner, round_bit, trun_mask)
         if clamp_acc_to_dl16:
-            accumulator = fp32_clamp_to_dl16(accumulator)
+            accumulator_inner = fp32_clamp_to_dl16(accumulator_inner)
         ## ---------------------------------------------------------
         if truncate_then_accumulate:
             accumulator += accumulator_inner
@@ -411,7 +411,7 @@ def matmul_kernel_DABC(
         if chunk_trun_bits > 0:
             accumulator_inner = round_and_trun(accumulator_inner, round_bit, trun_mask)
         if clamp_acc_to_dl16:
-            accumulator = fp32_clamp_to_dl16(accumulator)
+            accumulator_inner = fp32_clamp_to_dl16(accumulator_inner)
         ## ---------------------------------------------------------
         if truncate_then_accumulate:
             accumulator += accumulator_inner

--- a/fms_mo/custom_ext_kernels/triton_kernels.py
+++ b/fms_mo/custom_ext_kernels/triton_kernels.py
@@ -160,13 +160,8 @@ def matmul_kernel(
     # We accumulate into a `[BLOCK_SIZE_M, BLOCK_SIZE_N]` block
     # of fp32 values for higher accuracy.
     accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
-    ## ------ prepare LSB rounding/truncation masks -------
-    # NOTE mask will be applied on accumulator, which is alway FP32, so we may truncate up to 23b
-    # e.g., 20b -> trun_mask = 0xFFF00000, round_bit = 0x00080000
-    #        8b -> trun_mask = 0xFFFFFF00, round_bit = 0x00000080
-    trun_mask = ~tl.cast((1 << chunk_trun_bits) - 1, tl.uint32)
-    round_bit = 1 << (chunk_trun_bits - 1) if chunk_trun_bits > 0 else 0
-    ## ---------------------------------------------------------
+    ## ------ prepare LSB rounding/truncation masks outside the for loop -------
+    round_bit, trun_mask = round_and_trun_mask(chunk_trun_bits, clamp_acc_to_dl16)
 
     for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
         # Load the next block of A and B, generate a mask by checking the K dimension.
@@ -181,10 +176,10 @@ def matmul_kernel(
         # tl.dot() default is using TF32 approximation, not good enough for LSB truncation exp
 
         ## ------ add chunky LSB rounding/masking --------
-        if chunk_trun_bits > 0:
-            accumulator_inner = round_and_trun(accumulator_inner, round_bit, trun_mask)
-        if clamp_acc_to_dl16:
-            accumulator_inner = fp32_clamp_to_dl16(accumulator_inner)
+        if clamp_acc_to_dl16 or chunk_trun_bits > 0:
+            accumulator_inner = round_and_trun(
+                accumulator_inner, round_bit, trun_mask, clamp_acc_to_dl16
+            )
         ## ---------------------------------------------------------
         if truncate_then_accumulate:
             accumulator += accumulator_inner
@@ -382,13 +377,8 @@ def matmul_kernel_DABC(
     # We accumulate into a `[BLOCK_SIZE_M, BLOCK_SIZE_N]` block
     # of fp32 values for higher accuracy, i.e. C should have been cast to fp32 already
     accumulator = tl.load(c_ptrs, mask=c_mask, other=0.0)
-    ## ------ prepare LSB rounding/truncation masks -------
-    # NOTE mask will be applied on accumulator, which is alway FP32, so we may truncate up to 23b
-    # e.g., 20b -> trun_mask = 0xFFF00000, round_bit = 0x00080000
-    #        8b -> trun_mask = 0xFFFFFF00, round_bit = 0x00000080
-    trun_mask = ~tl.cast((1 << chunk_trun_bits) - 1, tl.uint32)
-    round_bit = 1 << (chunk_trun_bits - 1) if chunk_trun_bits > 0 else 0
-    ## ---------------------------------------------------------
+    ## ------ prepare LSB rounding/truncation masks outside the for loop -------
+    round_bit, trun_mask = round_and_trun_mask(chunk_trun_bits, clamp_acc_to_dl16)
 
     for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
         # Load the next block of A, B, and C, generate a mask by checking the K dimension.
@@ -408,10 +398,10 @@ def matmul_kernel_DABC(
         #       precision as well, hence, could lose some precision!
 
         ## ------ add chunky LSB rounding/masking --------
-        if chunk_trun_bits > 0:
-            accumulator_inner = round_and_trun(accumulator_inner, round_bit, trun_mask)
-        if clamp_acc_to_dl16:
-            accumulator_inner = fp32_clamp_to_dl16(accumulator_inner)
+        if clamp_acc_to_dl16 or chunk_trun_bits > 0:
+            accumulator_inner = round_and_trun(
+                accumulator_inner, round_bit, trun_mask, clamp_acc_to_dl16
+            )
         ## ---------------------------------------------------------
         if truncate_then_accumulate:
             accumulator += accumulator_inner
@@ -440,32 +430,62 @@ def leaky_relu(x):
 
 
 @triton.jit
-def round_and_trun(x, round_bit, trun_mask):
-    """Round and truncate (usually for accumulator)."""
-    return libdevice.uint_as_float((libdevice.float_as_uint(x) + round_bit) & trun_mask)
+def round_and_trun_mask(chunk_trun_bits, clamp_acc_to_dl16):
+    """
+    Rounding and LSB truncation masks only need to be generated once.
+    These mask will be applied on "inner" accumulator, which is alway FP32 (e8m23). We may truncate
+    up to 23b for mantissa. If DL16/DL8, pay attention to exponent bias.
+    Examples: 20b -> trun_mask = 0xFFF00000, round_bit = 0x00080000
+               8b -> trun_mask = 0xFFFFFF00, round_bit = 0x00000080
+    """
+    if clamp_acc_to_dl16:
+        # DL16 is e6m9, hence, truncate 23 - 9 = 14 bits
+        chunk_trun_bits = 14
+    round_bit = 1 << (chunk_trun_bits - 1) if chunk_trun_bits > 0 else 0
+    trun_mask = ~tl.cast((1 << chunk_trun_bits) - 1, tl.uint32)
+    return round_bit, trun_mask
 
 
 @triton.jit
-def fp32_clamp_to_dl16(x):
-    """clamp FP32 (1-8-23) TENSOR x to DL16 (1-6-9) range."""
-    # 1. rounding: add round bit, zero out last 13 bits, back to float
-    x = libdevice.float_as_uint(x)
-    round_bit = 1 << (23 - 9 - 1)
-    mask_13x0 = ~tl.cast((1 << 13) - 1, tl.uint32)
-    x = libdevice.uint_as_float((x + round_bit) & mask_13x0)
+def round_and_trun(x, round_bit, trun_mask, clamp_acc_to_dl16):
+    """Round and truncate (usually for accumulator)."""
+    x = libdevice.uint_as_float((libdevice.float_as_uint(x) + round_bit) & trun_mask)
 
-    # 2. clamp to min/max:
-    #   max = 2^32 * 1.(1111 1111 0)_base2 => 2^32*1.(1111 1111 1) will become inf
-    #         (32 + 127) << 23 | (0xFF8 << (23 - 12)) in FP32 is 8581545984.0
-    #   min = 2^-31 * 1.(0000 0000 1)_base2 => set to 0 for those smaller than this
-    #         (-31 + 127) << 23 | (1 << (23 - 9)) in FP32 is 4.665707820095122e-10
-    dl16_max = 8581545984.0
-    dl16_min = 4.665707820095122e-10
-    x = tl.where(x >= dl16_max, float("inf"), x)
-    x = tl.where(x <= -dl16_max, float("-inf"), x)
-    x = tl.where(tl.abs(x) < dl16_min, 0, x)
-
+    if clamp_acc_to_dl16:
+        # clamp to DL16 min/max:
+        #   max = 2^32 * 1.(1111 1111 0)_base2 = 2^32*(2 - 2^-9) = 8581545984.0
+        #         greater than this will become +inf (or -inf)
+        #   min = 2^-31 * 1.(0000 0000 1)_base2 = 2^-31*(1 + 2^-9)> = 4.665707820095122e-10
+        #         smaller than this will become 0
+        dl16_max = 8581545984.0
+        dl16_min = 4.665707820095122e-10
+        x = tl.where(x >= dl16_max, float("inf"), x)
+        x = tl.where(x <= -dl16_max, float("-inf"), x)
+        x = tl.where(tl.abs(x) < dl16_min, 0, x)
     return x
+
+
+# @triton.jit
+# def fp32_clamp_to_dl16(x):
+#     """clamp FP32 (1-8-23) TENSOR x to DL16 (1-6-9) range."""
+#     # 1. rounding: add round bit, zero out last 13 bits, back to float
+#     x = libdevice.float_as_uint(x)
+#     round_bit = 1 << (23 - 9 - 1)
+#     mask_13x0 = ~tl.cast((1 << 13) - 1, tl.uint32)
+#     x = libdevice.uint_as_float((x + round_bit) & mask_13x0)
+
+#     # 2. clamp to min/max:
+#     #   max = 2^32 * 1.(1111 1111 0)_base2 => 2^32*1.(1111 1111 1) will become inf
+#     #         (32 + 127) << 23 | (0xFF8 << (23 - 12)) in FP32 is 8581545984.0
+#     #   min = 2^-31 * 1.(0000 0000 1)_base2 => set to 0 for those smaller than this
+#     #         (-31 + 127) << 23 | (1 << (23 - 9)) in FP32 is 4.665707820095122e-10
+#     dl16_max = 8581545984.0
+#     dl16_min = 4.665707820095122e-10
+#     x = tl.where(x >= dl16_max, float("inf"), x)
+#     x = tl.where(x <= -dl16_max, float("-inf"), x)
+#     x = tl.where(tl.abs(x) < dl16_min, 0, x)
+
+#     return x
 
 
 def tl_matmul_chunk_truncate(

--- a/fms_mo/custom_ext_kernels/triton_kernels.py
+++ b/fms_mo/custom_ext_kernels/triton_kernels.py
@@ -448,10 +448,10 @@ def round_and_trun(x, round_bit, trun_mask):
 @triton.jit
 def fp32_clamp_to_dl16(x):
     """clamp FP32 (1-8-23) TENSOR x to DL16 (1-6-9) range."""
-    # 1. rounding, add round bit to full uint representation
+    # 1. rounding: add round bit to full uint representation, zero out last 13 bits, back to float
     x = libdevice.float_as_uint(x)
     round_bit = 1 << (23 - 9 - 1)
-    x = libdevice.uint_as_float(x + round_bit)
+    x = libdevice.uint_as_float(((x + round_bit) >> 13) << 13)
 
     # 2. clamp to min/max:
     #   max = 2^32 * 1.(1111 1111 0)_base2 => 2^32*1.(1111 1111 1) will become inf

--- a/fms_mo/custom_ext_kernels/triton_kernels.py
+++ b/fms_mo/custom_ext_kernels/triton_kernels.py
@@ -465,29 +465,6 @@ def round_and_trun(x, round_bit, trun_mask, clamp_acc_to_dl16):
     return x
 
 
-# @triton.jit
-# def fp32_clamp_to_dl16(x):
-#     """clamp FP32 (1-8-23) TENSOR x to DL16 (1-6-9) range."""
-#     # 1. rounding: add round bit, zero out last 13 bits, back to float
-#     x = libdevice.float_as_uint(x)
-#     round_bit = 1 << (23 - 9 - 1)
-#     mask_13x0 = ~tl.cast((1 << 13) - 1, tl.uint32)
-#     x = libdevice.uint_as_float((x + round_bit) & mask_13x0)
-
-#     # 2. clamp to min/max:
-#     #   max = 2^32 * 1.(1111 1111 0)_base2 => 2^32*1.(1111 1111 1) will become inf
-#     #         (32 + 127) << 23 | (0xFF8 << (23 - 12)) in FP32 is 8581545984.0
-#     #   min = 2^-31 * 1.(0000 0000 1)_base2 => set to 0 for those smaller than this
-#     #         (-31 + 127) << 23 | (1 << (23 - 9)) in FP32 is 4.665707820095122e-10
-#     dl16_max = 8581545984.0
-#     dl16_min = 4.665707820095122e-10
-#     x = tl.where(x >= dl16_max, float("inf"), x)
-#     x = tl.where(x <= -dl16_max, float("-inf"), x)
-#     x = tl.where(tl.abs(x) < dl16_min, 0, x)
-
-#     return x
-
-
 def tl_matmul_chunk_truncate(
     a,
     b,

--- a/fms_mo/custom_ext_kernels/utils.py
+++ b/fms_mo/custom_ext_kernels/utils.py
@@ -938,7 +938,7 @@ def lower_qmodel_triton(
         else:
             new_lin = LinearFPxAcc.from_nn(
                 m,
-                trun_bits=max_acc_bits,
+                trun_bits=num_lsb_to_truncate,
                 chunk_size=chunk_size,
                 dynamic_fp8=linFP_dyn_code,
                 clamp_acc_to_dl16=clamp_acc_to_dl16,

--- a/fms_mo/custom_ext_kernels/utils.py
+++ b/fms_mo/custom_ext_kernels/utils.py
@@ -873,6 +873,7 @@ def lower_qmodel_triton(
     clamp_acc_to_dl16=False,
     num_lsb_to_truncate=0,
     chunk_size=32,
+    layer_to_exclude=[],
 ):
     """
     Examplar GPU lowering function using triton. Only swap Linear/Qlinear in transformers.
@@ -916,7 +917,7 @@ def lower_qmodel_triton(
     )
 
     for name, m in model.named_modules():
-        if not isinstance(m, (QLinear, torch.nn.Linear)):
+        if not isinstance(m, (QLinear, torch.nn.Linear)) or name in layer_to_exclude:
             continue
         parent_name, module_name = _parent_name(name)
         parent_mod = model.get_submodule(parent_name)

--- a/fms_mo/custom_ext_kernels/utils.py
+++ b/fms_mo/custom_ext_kernels/utils.py
@@ -918,6 +918,12 @@ def lower_qmodel_triton(
 
     if layer_to_exclude is None:
         layer_to_exclude = []
+    elif isinstance(layer_to_exclude, str):
+        layer_to_exclude = [
+            layer_to_exclude,
+        ]
+    elif not isinstance(layer_to_exclude, (list, tuple)):
+        raise RuntimeError("layer_to_exclude has to be either str, list, or tuple.")
 
     for name, m in model.named_modules():
         if not isinstance(m, (QLinear, torch.nn.Linear)) or name in layer_to_exclude:

--- a/fms_mo/custom_ext_kernels/utils.py
+++ b/fms_mo/custom_ext_kernels/utils.py
@@ -873,7 +873,7 @@ def lower_qmodel_triton(
     clamp_acc_to_dl16=False,
     num_lsb_to_truncate=0,
     chunk_size=32,
-    layer_to_exclude=[],
+    layer_to_exclude=None,
 ):
     """
     Examplar GPU lowering function using triton. Only swap Linear/Qlinear in transformers.
@@ -915,6 +915,9 @@ def lower_qmodel_triton(
         if use_dyn_max_act
         else False
     )
+
+    if layer_to_exclude is None:
+        layer_to_exclude = []
 
     for name, m in model.named_modules():
         if not isinstance(m, (QLinear, torch.nn.Linear)) or name in layer_to_exclude:

--- a/fms_mo/dq.py
+++ b/fms_mo/dq.py
@@ -268,35 +268,9 @@ def run_dq(model_args, data_args, opt_args, fms_mo_args):
             max_acc_bits=qcfg.get("max_acc_bits", 32),
             num_lsb_to_truncate=qcfg.get("lsb_trun_bits", 0),
             chunk_size=qcfg.get("chunk_size", 32),  # 1024
-            clamp_acc_to_dl16=False,  # fms_mo_args.aiu_sim_triton == "fp8"
+            clamp_acc_to_dl16=fms_mo_args.aiu_sim_triton == "fp8",
             # layer_to_exclude=["lm_head",]
         )
-    # [CL] -------- record W, A, qW, qA with hooks ----------------
-    # from fms_mo.modules.linear import QLinear, QLinearINT8Deploy
-    # from fms_mo.quant.ptq import HookRecPostQuantInOut
-    #     cache_dict = {}
-    #     hook_handles = []
-    #     for n, m in model.named_modules():
-    #         if not isinstance(m, (QLinear, QLinearINT8Deploy, torch.nn.Linear)):
-    #             continue
-
-    #         m.mod_name = n
-    #         hook_handles.append(
-    #             m.register_forward_hook( HookRecPostQuantInOut(cache_dict, n))
-    #         )
-
-    #     data_mb = next(iter(eval_dataloader))
-    #     with torch.no_grad():
-    #         model(**data_mb)
-
-    #     for h in hook_handles:
-    #         h.remove()
-
-    #     torch.save(
-    #         cache_dict,
-    #         f"roberta_sqv2_data_dump_{qcfg['qa_mode']}_{qcfg['qw_mode']}_chunk64_lsb{args.aiu_int_lsb_trun}_dq.pt"
-    #     )
-    #     return
 
     if fms_mo_args.eval_ppl:
         path_test = Path(data_args.test_data_path)

--- a/fms_mo/fx/utils.py
+++ b/fms_mo/fx/utils.py
@@ -461,14 +461,14 @@ def model_size_Wb(mod, unit="MB", print_to_file=True, show_details=False):
                 w_mat.numel() * w_mat.element_size()
                 + b_mat.numel() * b_mat.element_size()
             )
-            w_dtype = w_mat.dtype
+            w_dtype = str(w_mat.dtype)
             w_shape = w_mat.shape
 
         elif isinstance(w, torch.Tensor):
             mem_use = w.numel() * w.element_size()
             if hasattr(m, "bias") and m.bias is not None:
                 mem_use += m.bias.numel() * m.bias.element_size()
-            w_dtype = w.dtype
+            w_dtype = str(w.dtype)
             w_shape = w.shape
 
         if w_shape:

--- a/fms_mo/modules/linear.py
+++ b/fms_mo/modules/linear.py
@@ -2076,10 +2076,17 @@ class LinearFPxAcc(torch.nn.Linear):
         """
         Returns an alternative string representation of the object.
         """
-        return (
-            f"in={self.in_features}, out={self.out_features}, bias={self.bias is not None}, "
-            f"trun_bits={self.trun_bits},fp8_dyn={self.fp8_dyn},chunk_size={self.chunk_size}"
-        )
+        repr_str = f"{self.in_features},{self.out_features}"
+        if self.bias is not None:
+            repr_str += f",bias={self.bias is not None}"
+        if self.trun_bits > 0:
+            repr_str += f",trun_bits={self.trun_bits}"
+        if self.fp8_dyn:
+            repr_str += f",fp8_dyn={self.fp8_dyn}"
+        if self.clamp_acc_to_dl16:
+            repr_str += f",use_DL16_acc"
+        repr_str += f",chunk_size={self.chunk_size}"
+        return repr_str
 
 
 class LinearFuncINT8FwdFP32Bwd(torch.autograd.Function):

--- a/fms_mo/modules/linear.py
+++ b/fms_mo/modules/linear.py
@@ -2084,7 +2084,7 @@ class LinearFPxAcc(torch.nn.Linear):
         if self.fp8_dyn:
             repr_str += f",fp8_dyn={self.fp8_dyn}"
         if self.clamp_acc_to_dl16:
-            repr_str += f",use_DL16_acc"
+            repr_str += ",use_DL16_acc"
         repr_str += f",chunk_size={self.chunk_size}"
         return repr_str
 

--- a/fms_mo/modules/linear.py
+++ b/fms_mo/modules/linear.py
@@ -2047,7 +2047,7 @@ class LinearFPxAcc(torch.nn.Linear):
             nnlin.in_features,
             nnlin.out_features,
             bias=nnlin.bias is not None,
-            device=target_device,
+            device="meta",
         )
 
         lin24acc.weight = nnlin.weight

--- a/fms_mo/training_args.py
+++ b/fms_mo/training_args.py
@@ -192,7 +192,7 @@ class FMSMOArguments(TypeChecker):
         default=2048, metadata={"help": "input sequence length after tokenization"}
     )
     eval_ppl: bool = field(default=False)
-    aiu_sim_triton: str = field(
+    aiu_sim_triton: Optional[str] = field(
         default=None,
         metadata={
             "help": (

--- a/fms_mo/training_args.py
+++ b/fms_mo/training_args.py
@@ -181,8 +181,15 @@ class FMSMOArguments(TypeChecker):
         default=2048, metadata={"help": "input sequence length after tokenization"}
     )
     eval_ppl: bool = field(default=False)
-    aiu_sim_triton: bool = field(
-        default=False, metadata={"help": ("AIU simulation with triton kernel")}
+    aiu_sim_triton: str = field(
+        default=None,
+        metadata={
+            "help": (
+                "AIU simulation with triton kernel. ['int8', 'fp8', None]\n"
+                "'int8' mode will trigger qmodel_prep() and swap QLinears"
+                "'fp8' mode will directly replace existing nn.Linears"
+            )
+        },
     )
     recompute_narrow_weights: bool = field(
         default=False,

--- a/fms_mo/utils/dq_utils.py
+++ b/fms_mo/utils/dq_utils.py
@@ -13,14 +13,20 @@
 # limitations under the License.
 """Utility functions for Direct Quantization" (DQ)."""
 
+# Standard
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 def config_quantize_smooth_layers(qcfg: dict):
     """Update qcfg with model-dependent config parameters:
     - qlayer_name_pattern: identifier of transformer layers containing linear layers
-    to quantize (if any, tracing is bypassed)
+        to quantize (if any, tracing is bypassed)
     - qskip_layer_name: full name of linear layers that will not be quantized
     - smoothq_scale_layers: identifier of linear layers to apply smoothquant on
-    - smoothq_act_scale_path: path to save/load smoothquant activation scales
+    - smoothq_act_scale_path: path to save/load smoothquant activation scales, should be kept
+        Path(f"./act_scales/{qcfg['model'].replace('/', '-')}.pt"), no need to specify here.
 
     Selected model is determined by comparing all architecture identifiers against
     `model` and `model_type` fields in qcfg.
@@ -98,23 +104,10 @@ def config_quantize_smooth_layers(qcfg: dict):
                     [31, 7],
                 ]
             ]
-        qcfg["smoothq_act_scale_path"] = "./act_scales/Mixtral-8x7B-v0.1.pt"
     elif any(model in qcfg["model"] for model in bigcode_architecture):
         qcfg["qlayer_name_pattern"] = ["transformer.h"]
         qcfg["smoothq_scale_layers"] = ["c_attn", "c_fc"]
         # NOTE: supported bigcode models do not need layer skip for large magnitude
-        if "granite-3b-base-v2" in qcfg["model"]:
-            qcfg["smoothq_act_scale_path"] = "./act_scales/granite_3b_base_v2_500_nw.pt"
-        if "granite-13b-base-v2" in qcfg["model"]:
-            qcfg["smoothq_act_scale_path"] = "./act_scales/granite_13b_base_v2.pt"
-        if "granite-20b-code-base" in qcfg["model"]:
-            qcfg["smoothq_act_scale_path"] = "./act_scales/graniteCodeHF_20b_base12.pt"
-        if "granite-20b-code-instruct" in qcfg["model"]:
-            qcfg["smoothq_act_scale_path"] = "./act_scales/graniteCodeHF_20b_base12.pt"
-        if "granite-34b-code-base" in qcfg["model"]:
-            qcfg["smoothq_act_scale_path"] = "./act_scales/graniteCodeHF_34b_base12.pt"
-        if "granite-34b-code-instruct" in qcfg["model"]:
-            qcfg["smoothq_act_scale_path"] = "./act_scales/graniteCodeHF_34b_base12.pt"
     elif "roberta" in qcfg["model"]:
         qcfg["act_scale_path"] = "./act_scales"
         qcfg["smoothq_scale_layers"] = [
@@ -126,4 +119,7 @@ def config_quantize_smooth_layers(qcfg: dict):
         qcfg["qskip_layer_name"] = []
         qcfg["qlayer_name_pattern"] = ["roberta.encoder"]
     else:
-        raise ValueError("The model architecture is not supported for DQ.")
+        logger.info(
+            "The model architecture is not supported for DQ. No architecture-specific settings is"
+            "applied. All Linear layers will be quantized, which may not yield the optimal results."
+        )


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

in addition to INT8 AIU simulation, now FP8 is added to the triton kernel. AIU FP8 is using "DL8" matmul accumulated in "DL16", slightly different from GPU's FP8 e4m3 accum in FP32 (GPU local accumulator only uses ~22bits mantissa).

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added (if that coverage is difficult, please briefly explain the reason)
- [X] I have ensured all unit tests pass

### Checklist for passing CI/CD:

<!-- Mark completed tasks with "- [x]" -->
- [X] All commits are signed showing "Signed-off-by: Name \<email@domain.com\>" with `git commit -signoff` or equivalent
- [X] PR title and commit messages adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Contribution is formatted with `tox -e fix`
- [X] Contribution passes linting with `tox -e lint`
- [X] Contribution passes spellcheck with `tox -e spellcheck`
- [X] Contribution passes all unit tests with `tox -e unit`

Note: CI/CD performs unit tests on multiple versions of Python from a fresh install.  There may be differences with your local environment and the test environment.