### PR TITLE
fix: qkvsync bug fix

### DIFF
--- a/fms_mo/fx/dynamo_utils.py
+++ b/fms_mo/fx/dynamo_utils.py
@@ -1228,7 +1228,7 @@ def model_analyzer(
     # Therefore, length of qcfg["qkvsync_my_1st_sibling"] will be much shorter and keys of this dict
     # won't exist in full list (like all_linears below).
     all_linears = set(
-        [n for n, m in model.named_modules() if isinstance(m, torch.nn.Linear)]
+        n for n, m in model.named_modules() if isinstance(m, torch.nn.Linear)
     )
 
     if any(k not in all_linears for k in qcfg["qkvsync_my_1st_sibling"]):
@@ -1242,9 +1242,8 @@ def model_analyzer(
                 lut_all_siblings[sib_1st].append(me)
 
         full_sib_list = {}
-        for me in lut_all_siblings:
+        for me, all_sibs in lut_all_siblings.items():
             partial_matches = [lin for lin in all_linears if me in lin]
-            all_sibs = lut_all_siblings[me]
             # here lin is full_name, me and all_sibs are partial
             for lin in partial_matches:
                 prefix = lin[: lin.index(me)]


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

`qkvsync` is a function in `model_analyzer` trying to find Linear layers with common input, e.g. Q, K, V, or gate/up (in Llama arch). The results by this searching, a dict like `{"q":"q", "k":"q", "v":"q", ...}`, will be saved in `qcfg["qkvsync_my_1st_siblings"]`. This dict is supposed to contain the **full layer name**, however, when graph breaks happens, `model_analyzer` can only identify partial names instead. Later functions attempt to use `model.get_submodule()` based on this dict will fail.

### How to verify the PR

run dq with bamba (`ibm-ai-platform/Bamba-9B-V2`)

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added (if that coverage is difficult, please briefly explain the reason)
- [X] I have ensured all unit tests pass

### Checklist for passing CI/CD:

<!-- Mark completed tasks with "- [x]" -->
- [X] All commits are signed showing "Signed-off-by: Name \<email@domain.com\>" with `git commit -signoff` or equivalent
- [X] PR title and commit messages adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Contribution is formatted with `tox -e fix`
- [X] Contribution passes linting with `tox -e lint`
- [X] Contribution passes spellcheck with `tox -e spellcheck`
- [X] Contribution passes all unit tests with `tox -e unit`

Note: CI/CD performs unit tests on multiple versions of Python from a fresh install.  There may be differences with your local environment and the test environment.