### PR TITLE
fix: Mark FP8 scale to have the same batch size as input

### DIFF
--- a/fms_mo/aiu_addons/fp8/fp8_attn.py
+++ b/fms_mo/aiu_addons/fp8/fp8_attn.py
@@ -317,6 +317,23 @@ if available_packages["fms"]:
             attn_kwargs["left_padded_prompt_mask"],
             attn_kwargs["block_table"],
         )
+    
+    def __spyre_scaled_paged_validate_attn_kwargs_op(
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor,
+        past_key_value_states: Optional[list[tuple[torch.Tensor, torch.Tensor]]] = None,
+        **attn_kwargs,
+    ):
+        __spyre_paged_validate_attn_kwargs_op(input_ids, position_ids, past_key_value_states, **attn_kwargs)
+
+        if past_key_value_states is not None:
+            for k, v in past_key_value_states:
+                assert isinstance(k, ScaledTensor)
+                assert isinstance(v, ScaledTensor)
+
+                # assert that for each layer, the scales are per-sequence
+                assert k._scale.shape[0] == input_ids.shape[0]
+                assert v._scale.shape[0] == input_ids.shape[0]
 
     register_attention_op(
         "spyre_paged_attn_fp8",
@@ -325,5 +342,5 @@ if available_packages["fms"]:
         is_prefill_op=lambda **attn_kwargs: attn_kwargs.get("block_table", None)
         is None,
         compute_decode_op=_spyre_scaled_paged_compute_op,
-        validate_attn_kwargs_op=__spyre_paged_validate_attn_kwargs_op,
+        validate_attn_kwargs_op=__spyre_scaled_paged_validate_attn_kwargs_op,
     )

--- a/fms_mo/aiu_addons/fp8/fp8_attn.py
+++ b/fms_mo/aiu_addons/fp8/fp8_attn.py
@@ -317,14 +317,16 @@ if available_packages["fms"]:
             attn_kwargs["left_padded_prompt_mask"],
             attn_kwargs["block_table"],
         )
-    
+
     def __spyre_scaled_paged_validate_attn_kwargs_op(
         input_ids: torch.Tensor,
         position_ids: torch.Tensor,
         past_key_value_states: Optional[list[tuple[torch.Tensor, torch.Tensor]]] = None,
         **attn_kwargs,
     ):
-        __spyre_paged_validate_attn_kwargs_op(input_ids, position_ids, past_key_value_states, **attn_kwargs)
+        __spyre_paged_validate_attn_kwargs_op(
+            input_ids, position_ids, past_key_value_states, **attn_kwargs
+        )
 
         if past_key_value_states is not None:
             for k, v in past_key_value_states:


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

This PR adds an assertion that the FP8 scales have the same batch dimension as the inputs for paged attention. This is important for torch compile to not create extra dynamic dimensions, which is needed for AIU compilation and also accelerates tracing.

<!-- Please summarize the changes -->

### Related issues or PRs

Internal AIU issue tracker.

<!-- For example: "Closes #1234" or "Fixes bug introduced in #5678 -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR if unit tests do not provide coverage.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added (if that coverage is difficult, please briefly explain the reason)
- [ ] I have ensured all unit tests pass

### Checklist for passing CI/CD:

<!-- Mark completed tasks with "- [x]" -->
- [ ] All commits are signed showing "Signed-off-by: Name \<email@domain.com\>" with `git commit -signoff` or equivalent
- [ ] PR title and commit messages adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Contribution is formatted with `tox -e fix`
- [ ] Contribution passes linting with `tox -e lint`
- [ ] Contribution passes spellcheck with `tox -e spellcheck`
- [ ] Contribution passes all unit tests with `tox -e unit`

Note: CI/CD performs unit tests on multiple versions of Python from a fresh install.  There may be differences with your local environment and the test environment.