### PR TITLE
fix: pylint false alarm on libdevice functions

### DIFF
--- a/fms_mo/custom_ext_kernels/triton_kernels.py
+++ b/fms_mo/custom_ext_kernels/triton_kernels.py
@@ -449,7 +449,7 @@ def round_and_trun_mask(chunk_trun_bits, clamp_acc_to_dl16):
 @triton.jit
 def round_and_trun(x, round_bit, trun_mask, clamp_acc_to_dl16):
     """Round and truncate (usually for accumulator)."""
-    x = libdevice.uint_as_float((libdevice.float_as_uint(x) + round_bit) & trun_mask)
+    x = libdevice.uint_as_float((libdevice.float_as_uint(x) + round_bit) & trun_mask)  # pylint: disable=assignment-from-no-return
 
     if clamp_acc_to_dl16:
         # clamp to DL16 min/max:

--- a/fms_mo/run_quant.py
+++ b/fms_mo/run_quant.py
@@ -155,7 +155,6 @@ def run_gptq(model_args, data_args, opt_args, gptq_args):
             v2_memory_device="cpu",
         )
 
-
     # Add custom model_type mapping to gptqmodel LUT so GPTQModel can recognize them.
     for mtype, cls in custom_gptq_classes.items():
         if mtype in MODEL_MAP:

--- a/fms_mo/training_args.py
+++ b/fms_mo/training_args.py
@@ -139,8 +139,8 @@ class OptArguments(TypeChecker):
 
     quant_method: str = field(
         metadata={
-            "choices": ["gptq", "gptqv2", "fp8", "dq"], 
-            "help": "Quantization technique"
+            "choices": ["gptq", "gptqv2", "fp8", "dq"],
+            "help": "Quantization technique",
         }
     )
     output_dir: str = field(
@@ -227,7 +227,6 @@ class GPTQArguments(TypeChecker):
     use_cuda_fp16: bool = True
     autotune_warmup_after_quantized: bool = False
     cache_examples_on_gpu: bool = True
-
 
 
 @dataclass


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

since ~ a week ago, pylint began to throw a "assignment-from-no-return" warning on `libdevice` functions in triton kernel. disable this false alarm.

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added (if that coverage is difficult, please briefly explain the reason)
- [X] I have ensured all unit tests pass

### Checklist for passing CI/CD:

<!-- Mark completed tasks with "- [x]" -->
- [X] All commits are signed showing "Signed-off-by: Name \<email@domain.com\>" with `git commit -signoff` or equivalent
- [X] PR title and commit messages adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Contribution is formatted with `tox -e fix`
- [X] Contribution passes linting with `tox -e lint`
- [X] Contribution passes spellcheck with `tox -e spellcheck`
- [X] Contribution passes all unit tests with `tox -e unit`

Note: CI/CD performs unit tests on multiple versions of Python from a fresh install.  There may be differences with your local environment and the test environment.