### PR TITLE
Change paged FP8 prefill back to regular attention

### DIFF
--- a/fms_mo/aiu_addons/fp8/fp8_attn.py
+++ b/fms_mo/aiu_addons/fp8/fp8_attn.py
@@ -21,6 +21,7 @@ import math
 import torch
 
 # Local
+from fms.modules.attention import _sdpa_compute_op
 from fms_mo.aiu_addons.fp8.fp8_utils import ScaledTensor
 from fms_mo.prep import available_packages
 import fms_mo.aiu_addons.fp8.fp8_spyre_op  # pylint: disable=unused-import
@@ -340,7 +341,7 @@ if available_packages["fms"]:
     register_attention_op(
         "spyre_paged_attn_fp8",
         _spyre_scaled_paged_store_op,
-        compute_op=_math_fp8_compute_op,
+        compute_op=_sdpa_compute_op,
         is_prefill_op=lambda **attn_kwargs: attn_kwargs.get("block_table", None)
         is None,
         compute_decode_op=_spyre_scaled_paged_compute_op,


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

Deeptools developers prefer the prefill for paged fp8 attention to be regular attention instead of the math fp8 attention, given that the FP8 projections return FP16 anyways and running attention in FP8 for prefill essentially requires casting activations to FP8 twice.

<!-- Please summarize the changes -->

### Related issues or PRs

Internal discussion.

<!-- For example: "Closes #1234" or "Fixes bug introduced in #5678 -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR if unit tests do not provide coverage.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added (if that coverage is difficult, please briefly explain the reason)
- [ ] I have ensured all unit tests pass

### Checklist for passing CI/CD:

<!-- Mark completed tasks with "- [x]" -->
- [ ] All commits are signed showing "Signed-off-by: Name \<email@domain.com\>" with `git commit -signoff` or equivalent
- [ ] PR title and commit messages adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Contribution is formatted with `tox -e fix`
- [ ] Contribution passes linting with `tox -e lint`
- [ ] Contribution passes spellcheck with `tox -e spellcheck`
- [ ] Contribution passes all unit tests with `tox -e unit`

Note: CI/CD performs unit tests on multiple versions of Python from a fresh install.  There may be differences with your local environment and the test environment.