### PR TITLE
fix: name check to support TP

### DIFF
--- a/fms_mo/aiu_addons/__init__.py
+++ b/fms_mo/aiu_addons/__init__.py
@@ -43,7 +43,7 @@ def _infer_quantization_config(quant_config: dict) -> dict | None:
                 for ignored_layer in quant_config["ignore"]:
                     assert isinstance(ignored_layer, str)
                     fms_ign_layer = translations.get(ignored_layer, ignored_layer)
-                    if name in fms_ign_layer:
+                    if name and name in fms_ign_layer:
                         return "torch_linear"
                 for pattern in quant_config["config_groups"]["group_0"]["targets"]:
                     # Special case from llm-compressor that covers all linear layers


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

This updates a check in `fp8_linear_type` to ensure the module name is not none before checking it against a string. 

See this todo here: https://github.com/foundation-model-stack/foundation-model-stack/blob/f4d8d1f062cf57d8258b52b18db7239722731553/fms/modules/attention.py#L779-L780

NB: I am not an expert here and don't know if this is correct

### Related issues or PRs


### How to verify the PR

Load the model `ibm-ai-platform/micro-g3.3-8b-instruct-1b-FP8` with TP>1 using fms

### Was the PR tested

Coverage is difficult because I don't know what the correct behavior should be, but this change at least gets around the error about checking None with the `in` operator

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added (if that coverage is difficult, please briefly explain the reason)
- [ ] I have ensured all unit tests pass

### Checklist for passing CI/CD:

<!-- Mark completed tasks with "- [x]" -->
- [ ] All commits are signed showing "Signed-off-by: Name \<email@domain.com\>" with `git commit -signoff` or equivalent
- [ ] PR title and commit messages adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Contribution is formatted with `tox -e fix`
- [ ] Contribution passes linting with `tox -e lint`
- [ ] Contribution passes spellcheck with `tox -e spellcheck`
- [ ] Contribution passes all unit tests with `tox -e unit`

Note: CI/CD performs unit tests on multiple versions of Python from a fresh install.  There may be differences with your local environment and the test environment.