### PR TITLE
fix: fixed fp8 import so as to not require user to import

### DIFF
--- a/fms_mo/aiu_addons/__init__.py
+++ b/fms_mo/aiu_addons/__init__.py
@@ -30,6 +30,7 @@ def _infer_quantization_config(quant_config: dict) -> dict | None:
                 )
             # First, import required FP8 linear classes from fms-mo
             # Local
+            import fms_mo.aiu_addons.fp8.fp8_attn  # pylint: disable=unused-import
             import fms_mo.aiu_addons.fp8.fp8_adapter  # pylint: disable=unused-import
             import fms_mo.aiu_addons.fp8.fp8_linear  # pylint: disable=unused-import
 


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

<!-- Please summarize the changes -->

Added an import as part of fp8 addons as this should not be required by the user and should happen implicitly.

### Related issues or PRs

<!-- For example: "Closes #1234" or "Fixes bug introduced in #5678 -->

https://github.com/foundation-model-stack/aiu-fms-testing-utils/pull/103

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR if unit tests do not provide coverage.-->

To verify the PR, run test_decoders in aftu with the following variables:

```
FMS_TEST_SHAPES_SKIP_ASSERTIONS=mean_diff 
FMS_TEST_SHAPES_USE_MICRO_MODELS=0 
FMS_TEST_SHAPES_COMMON_MODEL_PATHS=ibm-ai-platform/micro-g3.3-8b-instruct-1b-FP8  
FMS_TEST_SHAPES_COMMON_BATCH_SIZES=1 
FMS_TEST_SHAPES_COMMON_SEQ_LENGTHS=128 
FMS_TEST_SHAPES_FAILURE_THRESHOLD=0.06 
FMS_TEST_SHAPES_ATTN_TYPE=math_fp8
```

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added (if that coverage is difficult, please briefly explain the reason)
- [ ] I have ensured all unit tests pass

### Checklist for passing CI/CD:

<!-- Mark completed tasks with "- [x]" -->
- [ ] All commits are signed showing "Signed-off-by: Name \<email@domain.com\>" with `git commit -signoff` or equivalent
- [ ] PR title and commit messages adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Contribution is formatted with `tox -e fix`
- [ ] Contribution passes linting with `tox -e lint`
- [ ] Contribution passes spellcheck with `tox -e spellcheck`
- [ ] Contribution passes all unit tests with `tox -e unit`

Note: CI/CD performs unit tests on multiple versions of Python from a fresh install.  There may be differences with your local environment and the test environment.