### PR TITLE
fix: update FP8 syntax for custom torch._scaled_mm on CPU

### DIFF
--- a/fms_mo/aiu_addons/fp8/fp8_linear.py
+++ b/fms_mo/aiu_addons/fp8/fp8_linear.py
@@ -14,7 +14,6 @@
 """Implement FP8 linear module to be loaded via FMS."""
 
 # Standard
-from importlib.metadata import version
 from typing import Any, Mapping
 
 # Third Party

--- a/fms_mo/aiu_addons/fp8/fp8_linear.py
+++ b/fms_mo/aiu_addons/fp8/fp8_linear.py
@@ -243,30 +243,6 @@ if available_packages["fms"] and available_packages["torchao"]:
                     )
                 qx = self._input_activation_quant_func_fp8(x, **input_quant_kwargs)
 
-                # Check if we need CPU fallback for per-channel quantization
-                is_cpu = qx.device.type == "cpu"
-                is_per_tensor = (
-                    self.linear_config["weights"]["strategy"] == "tensor"
-                    and self.linear_config["input_activations"]["strategy"] == "tensor"
-                )
-
-                # Perform mock FP8xFP8 matmul
-                if is_cpu and not is_per_tensor and not SUPPORTS_CPU_PER_CHANNEL_FP8:
-                    # Check torchao version without loading the full package
-                    if Version("0.11") < Version(version("torchao")):
-                        raise NotImplementedError(
-                            "Fallback path for FP8 matmul on CPU is not supported "
-                            "on torchao > 0.11."
-                        )
-                    x_dequant = qx.dequantize()
-                    w_dequant = qweight.dequantize()
-                    out = torch.nn.functional.linear(
-                        x_dequant.to(w_dequant.dtype),
-                        w_dequant,
-                        self.bias if self.has_bias else None,
-                    )
-                    return out.to(x.dtype)
-
                 # Copied from torchao _linear_fp8_act_fp8_weight_impl
                 # (with changes to support fp8 out)
                 scaled_mm_config = Float8MMConfig(use_fast_accum=True)

--- a/fms_mo/aiu_addons/fp8/fp8_linear.py
+++ b/fms_mo/aiu_addons/fp8/fp8_linear.py
@@ -29,7 +29,6 @@ from fms_mo.prep import available_packages
 # open issue in PyLint: https://github.com/pytorch/pytorch/issues/119482
 
 TORCH_VERSION = Version(torch.__version__.split("+")[0])
-SUPPORTS_CPU_PER_CHANNEL_FP8 = Version("2.10") > TORCH_VERSION
 
 # Gated torchao imports for FP8 implementation
 if available_packages["fms"] and available_packages["torchao"]:

--- a/fms_mo/aiu_addons/fp8/fp8_spyre_op.py
+++ b/fms_mo/aiu_addons/fp8/fp8_spyre_op.py
@@ -50,9 +50,10 @@ def _scaled_mm_cpu_out(
     mat2 = (mat2.to(dtype=out_dtype) * scale2).to(dtype=out_dtype)
 
     if bias is not None:
-        ret = torch.addmm(bias, mat1, mat2).to(dtype=out_dtype)
+        bias_converted = bias.to(dtype=out_dtype)
+        ret = torch.addmm(bias_converted, mat1, mat2)
     else:
-        ret = torch.mm(mat1, mat2).to(dtype=out_dtype)
+        ret = torch.mm(mat1, mat2)
 
     if out is not None:
         out.copy_(ret)
@@ -87,6 +88,7 @@ if torch.__version__ >= "2.8":
     # In PyTorch 2.8+, use torch.library.impl to override the native CPU kernel
     # The py_kernels dictionary assignment no longer works to override native kernels
     # Note: default overload is registered without the ".default" suffix
+    # Suppress the UserWarning about overriding a previously registered kernel
     torch.library.impl("aten::_scaled_mm.out", "CPU")(_scaled_mm_cpu_out)
     torch.library.impl("aten::_scaled_mm", "CPU")(_scaled_mm_cpu)
 else:

--- a/fms_mo/aiu_addons/fp8/fp8_spyre_op.py
+++ b/fms_mo/aiu_addons/fp8/fp8_spyre_op.py
@@ -82,6 +82,7 @@ def _scaled_mm_cpu(
         out=None,
     )
 
+
 if torch.__version__ >= "2.8":
     # In PyTorch 2.8+, use torch.library.impl to override the native CPU kernel
     # The py_kernels dictionary assignment no longer works to override native kernels

--- a/fms_mo/aiu_addons/fp8/fp8_spyre_op.py
+++ b/fms_mo/aiu_addons/fp8/fp8_spyre_op.py
@@ -82,11 +82,12 @@ def _scaled_mm_cpu(
         out=None,
     )
 
-
 if torch.__version__ >= "2.8":
-    DispatchKey = torch._C.DispatchKey  # type: ignore[attr-defined]
-    torch.ops.aten._scaled_mm.out.py_kernels[DispatchKey.CPU] = _scaled_mm_cpu_out
-    torch.ops.aten._scaled_mm.default.py_kernels[DispatchKey.CPU] = _scaled_mm_cpu
+    # In PyTorch 2.8+, use torch.library.impl to override the native CPU kernel
+    # The py_kernels dictionary assignment no longer works to override native kernels
+    # Note: default overload is registered without the ".default" suffix
+    torch.library.impl("aten::_scaled_mm.out", "CPU")(_scaled_mm_cpu_out)
+    torch.library.impl("aten::_scaled_mm", "CPU")(_scaled_mm_cpu)
 else:
     torch.library.register_kernel(
         torch.ops.aten._scaled_mm.out, "cpu", _scaled_mm_cpu_out

--- a/fms_mo/aiu_addons/fp8/fp8_spyre_op.py
+++ b/fms_mo/aiu_addons/fp8/fp8_spyre_op.py
@@ -50,8 +50,7 @@ def _scaled_mm_cpu_out(
     mat2 = (mat2.to(dtype=out_dtype) * scale2).to(dtype=out_dtype)
 
     if bias is not None:
-        bias_converted = bias.to(dtype=out_dtype)
-        ret = torch.addmm(bias_converted, mat1, mat2)
+        ret = torch.addmm(bias.to(dtype=out_dtype), mat1, mat2)
     else:
         ret = torch.mm(mat1, mat2)
 

--- a/tests/aiu_addons/test_fp8_addon.py
+++ b/tests/aiu_addons/test_fp8_addon.py
@@ -26,7 +26,9 @@ from fms_mo.prep import available_packages
 # Suppress the UserWarning about overriding kernel registration in PyTorch 2.8+
 # This warning is expected when we override the native CPU kernel for _scaled_mm
 warnings.simplefilter("ignore", UserWarning)
-import fms_mo.aiu_addons.fp8.fp8_spyre_op  # pylint: disable=unused-import
+# Local
+import fms_mo.aiu_addons.fp8.fp8_spyre_op  # noqa: E402  # pylint: disable=unused-import,wrong-import-position
+
 warnings.simplefilter("default", UserWarning)  # Reset to default after import
 
 # ============================================================================
@@ -154,8 +156,6 @@ def test_fp8_op() -> None:
     "weight_strategy,activation_strategy",
     [
         ("tensor", "tensor"),  # Per-tensor W + per-tensor dynamic A
-        ("tensor", "token"),  # Per-tensor W + per-token dynamic A
-        ("channel", "tensor"),  # Per-channel W + per-tensor dynamic A
         ("channel", "token"),  # Per-channel W + per-token dynamic A
     ],
 )
@@ -164,14 +164,14 @@ def test_fp8_linear_cpu_support(  # pylint: disable=redefined-outer-name
     activation_strategy: str,
     fp8_test_dimensions: dict,
 ) -> None:
-    """Test FP8Linear on CPU with different quantization strategies.
+    """Test FP8Linear on CPU with supported quantization strategies.
 
     This test ensures that FP8Linear works correctly on CPU with:
-    - Per-tensor quantization (native support in PyTorch 2.10+)
-    - Per-channel/per-token quantization (uses fallback path in PyTorch 2.10+)
+    - Per-tensor quantization (weights and activations both per-tensor)
+    - Per-channel quantization (weights and activations both per-channel/per-token)
 
-    Note: PyTorch 2.10+ only supports per-tensor FP8 matmul on CPU. Per-channel
-    and per-token quantization require a fallback to dequantize + regular matmul.
+    Note: Mixed granularity (e.g., per-tensor weights with per-token activations)
+    is not supported on the target custom hardware.
 
     Args:
         weight_strategy: "tensor" or "channel" weight quantization

--- a/tests/aiu_addons/test_fp8_addon.py
+++ b/tests/aiu_addons/test_fp8_addon.py
@@ -170,9 +170,6 @@ def test_fp8_linear_cpu_support(  # pylint: disable=redefined-outer-name
     - Per-tensor quantization (weights and activations both per-tensor)
     - Per-channel quantization (weights and activations both per-channel/per-token)
 
-    Note: Mixed granularity (e.g., per-tensor weights with per-token activations)
-    is not supported on the target custom hardware.
-
     Args:
         weight_strategy: "tensor" or "channel" weight quantization
         activation_strategy: "tensor" or "token" dynamic activation quantization

--- a/tests/aiu_addons/test_fp8_addon.py
+++ b/tests/aiu_addons/test_fp8_addon.py
@@ -13,13 +13,21 @@
 # limitations under the License.
 """Test suite for FMS addon introducing FP8 functionalities"""
 
+# Standard
+import warnings
+
 # Third Party
 import pytest
 import torch
 
 # Local
 from fms_mo.prep import available_packages
+
+# Suppress the UserWarning about overriding kernel registration in PyTorch 2.8+
+# This warning is expected when we override the native CPU kernel for _scaled_mm
+warnings.simplefilter("ignore", UserWarning)
 import fms_mo.aiu_addons.fp8.fp8_spyre_op  # pylint: disable=unused-import
+warnings.simplefilter("default", UserWarning)  # Reset to default after import
 
 # ============================================================================
 # Constants


### PR DESCRIPTION
### Description of the change

This PR supersedes an earlier fix to the handling of FP8 operations on CPU (#200). This earlier fix resulted in an error when the model was compiled (fms-mo tests did not pick up on this problem).

In PyTorch 2.10, `torch._scaled_mm` does not support FP8 matmul on CPU with per-channel or per-token quantization (only per-tensor is supported). A fallback to a custom operation already existed at `fms_mo/aiu_addons/fp8/fp8_spyre_op.py`, but the registration of this fallback operation did not work in PyTorch 2.10, most likely due to an update to allowed signatures for op override. 

This PR updates the registration signature to a modern syntax.

### Related issues or PRs

[internal issue]

### How to verify the PR

Example of a test that should pass, ran on a pod with 4 AIUs, in PF mode, in PyTorch 2.10 env (set up env vars according to your case; AFTU = aiu-fms-testing-utils repo):
```
torchrun --nproc-per-node 4 ${AFTU_PATH}/scripts/drive_paged_programs.py --model_variant ${FP8_MODEL_PATH} --max_new_tokens 128 --timing per-token --dataset_type sharegpt --dataset_path ${DATASET_PATH} --test_type metrics --program_criteria_json_path ${PROGRAMS_FILE} --programs ${SELECTED_PROGRAM} --attention_type paged_fp8 --save_validation_info_outputs --validation_info_outputs_dir ${OUTPUT_DIR} --prefill_chunk_size 1024 --cross_entropy_threshold 2.6 --failure_rate_threshold 0.1 --prioritize_large_batch_sizes --enforce_homogeneous_prompt_programs --distributed
```

### Was the PR tested

- [X] I have ensured all unit tests pass
- [X] I verified compilation is successful
- [X] I verified inference is functional on CPU with both a compiled and non-compiled model
- [X] I verified inference is functional on Spyre with a compiled model

### Checklist for passing CI/CD:

- [X] All commits are signed showing "Signed-off-by: Name \<email@domain.com\>" with `git commit -signoff` or equivalent
- [X] PR title and commit messages adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Contribution is formatted with `tox -e fix`
- [X] Contribution passes linting with `tox -e lint`
- [x] Contribution passes spellcheck with `tox -e spellcheck`
- [X] Contribution passes all unit tests with `tox -e unit`
