### PR TITLE
feat: update transformers to 5.x

### DIFF
--- a/fms_mo/dq.py
+++ b/fms_mo/dq.py
@@ -88,8 +88,7 @@ def run_dq(model_args, data_args, opt_args, fms_mo_args):
     config_kwargs = {
         "cache_dir": model_args.cache_dir,
         "revision": model_args.model_revision,
-        "use_auth_token": True if model_args.use_auth_token else None,
-        "torchscript": True,
+        "token": True if model_args.use_auth_token else None,
         "attn_implementation": attn_implementation,
     }
     config = AutoConfig.from_pretrained(model_args.model_name_or_path, **config_kwargs)
@@ -97,7 +96,7 @@ def run_dq(model_args, data_args, opt_args, fms_mo_args):
         "cache_dir": model_args.cache_dir,
         "use_fast": model_args.use_fast_tokenizer,
         "revision": model_args.model_revision,
-        "use_auth_token": True if model_args.use_auth_token else None,
+        "token": True if model_args.use_auth_token else None,
     }
     tokenizer = AutoTokenizer.from_pretrained(
         model_args.model_name_or_path, **tokenizer_kwargs
@@ -121,7 +120,7 @@ def run_dq(model_args, data_args, opt_args, fms_mo_args):
         config=config,
         cache_dir=model_args.cache_dir,
         revision="main",
-        use_auth_token=True if model_args.use_auth_token else None,
+        token=True if model_args.use_auth_token else None,
         torch_dtype=torch_dtype,
         device_map=model_args.device_map,
         low_cpu_mem_usage=bool(model_args.device_map),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dynamic = ["version"]
 dependencies = [
 "numpy>=1.26.4,<2.3.0",
 "accelerate>=0.20.3,!=0.34,<1.11",
-"transformers>=4.45,<4.58",
+"transformers>4.45,<5.9",
 "torch>=2.2.0,<2.11.0",
 "tqdm>=4.66.2,<5.0",
 "datasets>=3.0.0,<5.0",
@@ -36,6 +36,7 @@ dependencies = [
 [project.optional-dependencies]
 examples = ["ninja>=1.11.1.1,<2.0", "evaluate", "huggingface_hub"]
 fp8 = ["llmcompressor", "torchao==0.11"]  # FP8 matmul on CPU needs a fix before advancing torchao > 0.11
+fp8-infer = ["torchao==0.11"]
 gptq = ["Cython", "gptqmodel>=1.7.3"]
 mx = ["microxcaling>=1.1"]
 opt = ["fms-model-optimizer[fp8, gptq, mx]"]

--- a/tests/build/test_launch_script.py
+++ b/tests/build/test_launch_script.py
@@ -242,7 +242,6 @@ def _validate_termination_files_when_quantization_succeeds(base_dir):
     """Check whether the termination log and .complete files exists"""
     assert os.path.exists(os.path.join(base_dir, "/termination-log")) is False
     assert os.path.exists(os.path.join(base_dir, ".complete")) is True
-    # assert os.path.exists(os.path.join(base_dir, training_logs_filename)) is True
 
 
 def _validate_quantization_output(base_dir, quant_method):
@@ -256,7 +255,6 @@ def _validate_quantization_output(base_dir, quant_method):
         assert os.path.exists(os.path.join(base_dir, "special_tokens_map.json")) is True
 
     assert os.path.exists(os.path.join(base_dir, "tokenizer_config.json")) is True
-    # assert os.path.exists(os.path.join(base_dir, "tokenizer.model")) is True
 
     # Check quantized model files exist
     if quant_method == "gptq":

--- a/tests/build/test_launch_script.py
+++ b/tests/build/test_launch_script.py
@@ -250,7 +250,9 @@ def _validate_quantization_output(base_dir, quant_method):
     assert os.path.exists(os.path.join(base_dir, "tokenizer.json")) is True
 
     # special_tokens_map.json is optional in transformers 5.0+ for some tokenizers
-    transformers_version = tuple(int(x) for x in transformers.__version__.split(".")[:2])
+    transformers_version = tuple(
+        int(x) for x in transformers.__version__.split(".")[:2]
+    )
     if transformers_version < (5, 0):
         assert os.path.exists(os.path.join(base_dir, "special_tokens_map.json")) is True
 

--- a/tests/build/test_launch_script.py
+++ b/tests/build/test_launch_script.py
@@ -22,6 +22,7 @@ import glob
 # Third Party
 import pytest
 import torch
+import transformers
 
 # First Party
 from build.accelerate_launch import main
@@ -248,7 +249,12 @@ def _validate_quantization_output(base_dir, quant_method):
     """Check whether the tokenizer and quantized model artifacts exists"""
     # Check tokenizer files exist
     assert os.path.exists(os.path.join(base_dir, "tokenizer.json")) is True
-    assert os.path.exists(os.path.join(base_dir, "special_tokens_map.json")) is True
+
+    # special_tokens_map.json is optional in transformers 5.0+ for some tokenizers
+    transformers_version = tuple(int(x) for x in transformers.__version__.split(".")[:2])
+    if transformers_version < (5, 0):
+        assert os.path.exists(os.path.join(base_dir, "special_tokens_map.json")) is True
+
     assert os.path.exists(os.path.join(base_dir, "tokenizer_config.json")) is True
     # assert os.path.exists(os.path.join(base_dir, "tokenizer.model")) is True
 

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -39,6 +39,7 @@ import numpy as np
 import pytest
 import torch
 import torch.nn.functional as F
+import transformers
 
 # Local
 # fms_mo imports
@@ -1302,6 +1303,10 @@ def model_bert():
     Returns:
         transformers.models.bert.modeling_bert.BertModel: BERT model
     """
+    # torchscript parameter removed in transformers 5.0
+    transformers_version = tuple(int(x) for x in transformers.__version__.split(".")[:2])
+    if transformers_version >= (5, 0):
+        return BertModel.from_pretrained("google-bert/bert-base-uncased")
     return BertModel.from_pretrained("google-bert/bert-base-uncased", torchscript=True)
 
 
@@ -1313,6 +1318,12 @@ def model_bert_eager():
     Returns:
         transformers.models.bert.modeling_bert.BertModel: BERT model
     """
+    # torchscript parameter removed in transformers 5.0
+    transformers_version = tuple(int(x) for x in transformers.__version__.split(".")[:2])
+    if transformers_version >= (5, 0):
+        return BertModel.from_pretrained(
+            "google-bert/bert-base-uncased", attn_implementation="eager"
+        )
     return BertModel.from_pretrained(
         "google-bert/bert-base-uncased", torchscript=True, attn_implementation="eager"
     )

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -1304,7 +1304,9 @@ def model_bert():
         transformers.models.bert.modeling_bert.BertModel: BERT model
     """
     # torchscript parameter removed in transformers 5.0
-    transformers_version = tuple(int(x) for x in transformers.__version__.split(".")[:2])
+    transformers_version = tuple(
+        int(x) for x in transformers.__version__.split(".")[:2]
+    )
     if transformers_version >= (5, 0):
         return BertModel.from_pretrained("google-bert/bert-base-uncased")
     return BertModel.from_pretrained("google-bert/bert-base-uncased", torchscript=True)
@@ -1319,7 +1321,9 @@ def model_bert_eager():
         transformers.models.bert.modeling_bert.BertModel: BERT model
     """
     # torchscript parameter removed in transformers 5.0
-    transformers_version = tuple(int(x) for x in transformers.__version__.split(".")[:2])
+    transformers_version = tuple(
+        int(x) for x in transformers.__version__.split(".")[:2]
+    )
     if transformers_version >= (5, 0):
         return BertModel.from_pretrained(
             "google-bert/bert-base-uncased", attn_implementation="eager"

--- a/tests/models/test_qmodelprep.py
+++ b/tests/models/test_qmodelprep.py
@@ -272,6 +272,10 @@ def test_vit_dynamo(
     qmodule_error(model_vit, 2, 36)
 
 
+@pytest.mark.skipif(
+    not available_packages["torchvision"],
+    reason="Requires torchvision",
+)
 def test_resnet18(
     model_resnet18,
     batch_resnet18,
@@ -290,6 +294,10 @@ def test_resnet18(
     qmodule_error(model_resnet18, 4, 17)
 
 
+@pytest.mark.skipif(
+    not available_packages["torchvision"],
+    reason="Requires torchvision",
+)
 def test_vit_base(
     model_vit_base,
     batch_vit_base,

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ description = run tests (unit, unitcov)
 extras =
     dev
     test
+    torchvision
 package = wheel
 wheel_build_env = pkg
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ description = run tests (unit, unitcov)
 extras =
     dev
     test
-    torchvision
 package = wheel
 wheel_build_env = pkg
 deps =


### PR DESCRIPTION
### Description of the change

This PR implements support to upgrade transformer to >5.0 (tested with 5.8).

List of changes:
- upgraded requirements to `transformers < 5.9`
- added optional dependency group in `pyproject.toml` called `fp8-infer` to avoid loading `llm_compressor` (not used at inference by FMS-MO)
- `use_auth_token` no longer supported in the new `transformers`; replaced with `auth` (note: model_args `use_auth_token` remains unchanged for backward compatibility)
- `special_token_map.json` no longer provided by tokenizer; gated assertion to transformer version
- `torchscript` argument no longer supported in `BertModel.from_pretrained()`; gated passing this argument to transformer version
- `resnet18` and `vit` now require `torchvision`; skipping related tests if not installed 

### Related issues or PRs

Closes #203 

### Was the PR tested

- [X] I have ensured all unit tests pass (but triton tests fail locally)

### Checklist for passing CI/CD:

- [X] All commits are signed showing "Signed-off-by: Name \<email@domain.com\>" with `git commit -signoff` or equivalent
- [X] PR title and commit messages adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Contribution is formatted with `tox -e fix`
- [X] Contribution passes linting with `tox -e lint`
- [X] Contribution passes spellcheck with `tox -e spellcheck`
- [X] Contribution passes all unit tests with `tox -e unit`

Note: CI/CD performs unit tests on multiple versions of Python from a fresh install.  There may be differences with your local environment and the test environment.