### PR TITLE
feat: advance supported version of transformers package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dynamic = ["version"]
 dependencies = [
 "numpy>=1.26.4,<2.3.0",
 "accelerate>=0.20.3,!=0.34,<1.11",
-"transformers>4.45,<5.9",
+"transformers>4.45,<=5.12.1",
 "torch>=2.2.0,<2.12.0",
 "tqdm>=4.66.2,<5.0",
 "datasets>=3.0.0,<5.0",


### PR DESCRIPTION
### Description of the change

This PR simply advances the supported version of transformers from <5.9 to <=5.12.1 with a change to `pyproject.toml`.

Testing: verified all unit tests are passing within an environment based on python 3.12, torch 2.11, and:
1) transformers 5.12.1 (max version currently available that is compatible with torch 2.11)
2) transformers 5.10.2 (requested version to support)

### Related issues or PRs

n/a

### Was the PR tested

- [X] I have ensured all unit tests pass